### PR TITLE
feat: extend mef record with sources

### DIFF
--- a/rero_mef/authorities/api.py
+++ b/rero_mef/authorities/api.py
@@ -89,19 +89,6 @@ class MefRecord(AuthRecord):
     fetcher = mef_id_fetcher
     provider = MefProvider
 
-    def dumps(self, **kwargs):
-        """Return pure Python dictionary with record metadata."""
-        data = super(MefRecord, self).dumps(**kwargs)
-        sources = []
-        if 'rero' in data:
-            sources.append('rero')
-        if 'gnd' in data:
-            sources.append('gnd')
-        if 'bnf' in data:
-            sources.append('bnf')
-        data['sources'] = sources
-        return data
-
     @classmethod
     def build_ref_string(cls, agency_pid, agency):
         """Buid url for agency's api."""

--- a/rero_mef/ext.py
+++ b/rero_mef/ext.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of RERO MEF.
-# Copyright (C) 2018 RERO.
+# Copyright (C) 2017 RERO.
 #
 # RERO MEF is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -22,10 +22,26 @@
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
-"""RERO MEF."""
+"""RERO MEF invenio module declaration."""
 
 from __future__ import absolute_import, print_function
-from .version import __version__
-from .ext import REROMEFAPP
 
-__all__ = ('__version__', 'REROMEFAPP')
+
+class REROMEFAPP(object):
+    """rero-mef extension."""
+
+    def __init__(self, app=None):
+        """RERO MEF App module."""
+        if app:
+            self.init_app(app)
+            self.register_signals()
+
+    def init_app(self, app):
+        """Flask application initialization."""
+        app.extensions['rero-mef'] = self
+
+    def register_signals(app):
+        """Register signals."""
+        from .receivers import extend_mef_record
+        from invenio_indexer.signals import before_record_index
+        before_record_index.connect(extend_mef_record, weak=False)

--- a/rero_mef/receivers.py
+++ b/rero_mef/receivers.py
@@ -22,10 +22,30 @@
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
-"""RERO MEF."""
+"""Signals connections for RERO-MEF."""
 
-from __future__ import absolute_import, print_function
-from .version import __version__
-from .ext import REROMEFAPP
+from flask import current_app
 
-__all__ = ('__version__', 'REROMEFAPP')
+
+def extend_mef_record(
+    sender=None,
+    json=None,
+    record=None,
+    index=None,
+    doc_type=None
+):
+    """Extend MEF record with list of sources."""
+    mef_doc_type = current_app.config.get(
+        'RECORDS_REST_ENDPOINTS', {}).get(
+        'mef', {}
+    ).get('search_type', '')
+    if doc_type == mef_doc_type:
+        sources = []
+        # TODO: add the list of sources into the current_app.config
+        if 'rero' in json:
+            sources.append('rero')
+        if 'gnd' in json:
+            sources.append('gnd')
+        if 'bnf' in json:
+            sources.append('bnf')
+        json['sources'] = sources

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,9 @@ setup(
         'console_scripts': [
             'rero-mef = invenio_app.cli:cli',
         ],
+        'invenio_base.apps': [
+            'rero-mef = rero_mef.ext:REROMEFAPP'
+        ],
         'invenio_config.module': [
             'rero_mef = rero_mef.config',
         ],

--- a/tests/authorities/test_authorities_api.py
+++ b/tests/authorities/test_authorities_api.py
@@ -137,7 +137,7 @@ def test_update_agency_record_with_viaf_links(
     assert returned_rero_record['pid'] == 'A023655346'
 
 
-def test_mef_record_with(app, viaf_record):
+def test_mef_record(app, viaf_record):
     """Test MEF record."""
     viaf_pid = viaf_record['viaf_pid']
     mef_rec = MefRecord.get_mef_by_viaf_pid(

--- a/tests/authorities/test_signals.py
+++ b/tests/authorities/test_signals.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of RERO MEF.
+# Copyright (C) 2018 RERO.
+#
+# RERO MEF is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# RERO MEF is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with RERO MEF; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, RERO does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""Test signals."""
+
+from invenio_search import current_search
+
+from rero_mef.authorities.api import BnfRecord, GndRecord, MefSearch, \
+    ViafRecord
+
+
+def update_indexes(agency):
+    data = {
+        'auth': 'authorities-',
+        'agency': agency,
+        'person': '-person-v0.0.1'
+    }
+    index = '{auth}{agency}{person}'.format(**data)
+    current_search.flush_and_refresh(index=index)
+
+
+def test_create_mef_from_agency_with_viaf_links(
+        app, viaf_record, bnf_record, gnd_record):
+    """Test create MEF record from agency with viaf links."""
+    returned_record, status = ViafRecord.create_or_update(
+        viaf_record, agency='viaf', dbcommit=True, reindex=True
+    )
+    update_indexes('viaf')
+    assert status == 'create'
+    assert returned_record['viaf_pid'] == '66739143'
+    assert returned_record['bnf_pid'] == '10000690'
+    assert returned_record['gnd_pid'] == '12391664X'
+    assert returned_record['rero_auth_pid'] == 'A023655346'
+
+    returned_bnf_record, bnf_status = BnfRecord.create_or_update(
+        bnf_record, agency='bnf', dbcommit=True, reindex=True
+    )
+    update_indexes('bnf')
+    update_indexes('mef')
+    assert bnf_status == 'create'
+    assert returned_bnf_record['pid'] == '10000690'
+
+    returned_gnd_record, gnd_status = GndRecord.create_or_update(
+        gnd_record, agency='gnd', dbcommit=True, reindex=True
+    )
+    update_indexes('gnd')
+    update_indexes('mef')
+    assert gnd_status == 'create'
+    assert returned_gnd_record['pid'] == '12391664X'
+
+    key = '{agency}{identifier}'.format(agency='bnf', identifier='.pid')
+    result = MefSearch().filter(
+        'term', **{key: '10000690'}).source().scan()
+    sources = [n['sources'] for n in result]
+    assert sources[0] == ['gnd', 'bnf']


### PR DESCRIPTION
Signed-off-by: Aly Badr <aly.badr@rero.ch>
Co-author: Peter Weber <peter.weber@rero.ch>

To test:
pip install -e .[all]
./scripts/bootstrap
./scripts/setup
./run-tests

Display the mef records:

http://localhost:5000/api/mef/?q=&prettyprint=1&size=100
and ensure you have the "sources" field for each mef record