### PR TITLE
records: rename classes

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -12,7 +12,7 @@ description = "A database migration tool for SQLAlchemy."
 name = "alembic"
 optional = false
 python-versions = ">=3.6"
-version = "1.7.1"
+version = "1.7.3"
 
 [package.dependencies]
 Mako = "*"
@@ -167,7 +167,7 @@ description = "A simple, correct PEP517 package builder"
 name = "build"
 optional = false
 python-versions = ">=3.6"
-version = "0.6.1"
+version = "0.7.0"
 
 [package.dependencies]
 colorama = "*"
@@ -181,8 +181,8 @@ version = ">=0.22"
 
 [package.extras]
 docs = ["furo (>=2020.11.19b18)", "sphinx (>=3.0,<4.0)", "sphinx-argparse-cli (>=1.5)", "sphinx-autodoc-typehints (>=1.10)"]
-test = ["filelock (>=3)", "pytest (>=4)", "pytest-cov (>=2)", "pytest-mock (>=2)", "pytest-rerunfailures (>=9.1)", "pytest-xdist (>=1.34)", "setuptools (>=42.0.0)", "toml (>=0.10.0)", "wheel (>=0.36.0)"]
-typing = ["mypy (0.910)", "typing-extensions (>=3.7.4.3)"]
+test = ["filelock (>=3)", "pytest (>=6.2.4)", "pytest-cov (>=2)", "pytest-mock (>=2)", "pytest-rerunfailures (>=9.1)", "pytest-xdist (>=1.34)", "setuptools (>=42.0.0)", "toml (>=0.10.0)", "wheel (>=0.36.0)"]
+typing = ["importlib-metadata (>=4.6.4)", "mypy (0.910)", "typing-extensions (>=3.7.4.3)"]
 virtualenv = ["virtualenv (>=20.0.35)"]
 
 [[package]]
@@ -280,7 +280,7 @@ marker = "python_version >= \"3\""
 name = "charset-normalizer"
 optional = false
 python-versions = ">=3.5.0"
-version = "2.0.4"
+version = "2.0.6"
 
 [package.extras]
 unicode_backport = ["unicodedata2"]
@@ -291,7 +291,7 @@ description = "Check MANIFEST.in in a Python source package for completeness"
 name = "check-manifest"
 optional = false
 python-versions = ">=3.6"
-version = "0.46"
+version = "0.47"
 
 [package.dependencies]
 build = ">=0.1"
@@ -392,7 +392,7 @@ description = "Decorators for Humans"
 name = "decorator"
 optional = false
 python-versions = ">=3.5"
-version = "5.0.9"
+version = "5.1.0"
 
 [[package]]
 category = "main"
@@ -520,13 +520,13 @@ description = "A simple framework for building complex web applications."
 name = "flask"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "1.1.2"
+version = "1.1.4"
 
 [package.dependencies]
-Jinja2 = ">=2.10.1"
-Werkzeug = ">=0.15"
-click = ">=5.1"
-itsdangerous = ">=0.24"
+Jinja2 = ">=2.10.1,<3.0"
+Werkzeug = ">=0.15,<2.0"
+click = ">=5.1,<8.0"
+itsdangerous = ">=0.24,<2.0"
 
 [package.extras]
 dev = ["pytest", "coverage", "tox", "sphinx", "pallets-sphinx-themes", "sphinxcontrib-log-cabinet", "sphinx-issues"]
@@ -1084,9 +1084,10 @@ description = "Invenio user management and authentication."
 name = "invenio-accounts"
 optional = false
 python-versions = "*"
-version = "1.4.4"
+version = "1.4.6"
 
 [package.dependencies]
+Flask = ">=1.1.4,<2.0.0"
 Flask-Breadcrumbs = ">=0.4.0"
 Flask-KVSession-Invenio = ">=0.6.3"
 Flask-Login = ">=0.3.0,<0.5.0"
@@ -1097,7 +1098,7 @@ Flask-WTF = ">=0.14.3"
 cryptography = ">=3.0.0"
 email-validator = ">=1.0.5"
 future = ">=0.16.0"
-invenio-base = ">=1.2.3"
+invenio-base = ">=1.2.4"
 invenio-celery = ">=1.1.2"
 invenio-i18n = ">=1.2.0"
 invenio-rest = ">=1.2.1"
@@ -1294,10 +1295,10 @@ description = "Jinja utilities for Invenio."
 name = "invenio-formatter"
 optional = false
 python-versions = "*"
-version = "1.1.1"
+version = "1.1.2"
 
 [package.dependencies]
-Flask = ">=1.0.4,<2.0"
+Flask = ">=1.1.4,<2.0"
 Flask-BabelEx = ">=0.9.4"
 arrow = ">=0.7.0"
 bleach = ">=3.1.0"
@@ -1449,31 +1450,31 @@ description = "Invenio module that implements OAI-PMH server."
 name = "invenio-oaiserver"
 optional = false
 python-versions = "*"
-version = "1.2.1"
+version = "1.2.2"
 
 [package.dependencies]
-arrow = ">=0.13.0"
+Flask = ">=1.0.4,<2.0"
+arrow = ">=0.17.0"
+click = ">=7.0,<8.0"
 dojson = ">=1.3.0"
-invenio-base = ">=1.2.2"
+invenio-base = ">=1.2.4"
 invenio-i18n = ">=1.2.0"
-invenio-pidstore = ">=1.2.0"
-invenio-records = ">=1.3.0"
+invenio-pidstore = ">=1.2.2"
+invenio-records = ">=1.4.0"
 invenio-rest = ">=1.2.1"
 lxml = ">=4.3.0"
 
 [package.extras]
 admin = ["invenio-admin (>=1.2.0)"]
-all = ["invenio-admin (>=1.2.0)", "invenio-celery (>=1.2.0)", "Sphinx (>=3)", "SQLAlchemy-Continuum (>=1.3.6)", "invenio-indexer (>=1.1.0)", "invenio-jsonschemas (>=1.1.0)", "invenio-marc21 (>=1.0.0a9)", "mock (>=1.3.0)", "pytest-invenio (>=1.4.0)"]
-celery = ["invenio-celery (>=1.2.0)"]
-docs = ["Sphinx (>=3)"]
-elasticsearch2 = ["invenio-search (>=1.2.0)"]
-elasticsearch5 = ["invenio-search (>=1.2.0)"]
-elasticsearch6 = ["invenio-search (>=1.2.0)"]
-elasticsearch7 = ["invenio-search (>=1.2.0)"]
-mysql = ["invenio-db (>=1.0.0)"]
-postgresql = ["invenio-db (>=1.0.4)"]
-sqlite = ["invenio-db (>=1.0.0)"]
-tests = ["SQLAlchemy-Continuum (>=1.3.6)", "invenio-indexer (>=1.1.0)", "invenio-jsonschemas (>=1.1.0)", "invenio-marc21 (>=1.0.0a9)", "mock (>=1.3.0)", "pytest-invenio (>=1.4.0)"]
+all = ["invenio-admin (>=1.2.0)", "invenio-celery (>=1.2.2)", "Sphinx (>=3.1.0,<3.4.2)", "SQLAlchemy-Continuum (>=1.3.6)", "SQLAlchemy (>=1.2.18,<1.4.0)", "SQLAlchemy-Utils (>=0.33.1,<0.36)", "invenio-indexer (>=1.1.0)", "invenio-jsonschemas (>=1.1.0)", "invenio-marc21 (>=1.0.0a9)", "mock (>=1.3.0)", "pytest-invenio (>=1.4.1)"]
+celery = ["invenio-celery (>=1.2.2)"]
+docs = ["Sphinx (>=3.1.0,<3.4.2)"]
+elasticsearch6 = ["invenio-search (>=1.4.2,<2.0.0)"]
+elasticsearch7 = ["invenio-search (>=1.4.2,<2.0.0)"]
+mysql = ["invenio-db (>=1.0.9)"]
+postgresql = ["invenio-db (>=1.0.9)"]
+sqlite = ["invenio-db (>=1.0.9)"]
+tests = ["SQLAlchemy-Continuum (>=1.3.6)", "SQLAlchemy (>=1.2.18,<1.4.0)", "SQLAlchemy-Utils (>=0.33.1,<0.36)", "invenio-indexer (>=1.1.0)", "invenio-jsonschemas (>=1.1.0)", "invenio-marc21 (>=1.0.0a9)", "mock (>=1.3.0)", "pytest-invenio (>=1.4.1)"]
 
 [[package]]
 category = "main"
@@ -1839,11 +1840,11 @@ requirements_deprecated_finder = ["pipreqs", "pip-api"]
 
 [[package]]
 category = "main"
-description = "Safely pass data to untrusted environments and back."
+description = "Various helpers to pass data to untrusted environments and back."
 name = "itsdangerous"
 optional = false
-python-versions = ">=3.6"
-version = "2.0.1"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "1.1.0"
 
 [[package]]
 category = "main"
@@ -1865,14 +1866,14 @@ category = "main"
 description = "A very fast and expressive template engine."
 name = "jinja2"
 optional = false
-python-versions = ">=3.6"
-version = "3.0.1"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "2.11.3"
 
 [package.dependencies]
-MarkupSafe = ">=2.0"
+MarkupSafe = ">=0.23"
 
 [package.extras]
-i18n = ["Babel (>=2.7)"]
+i18n = ["Babel (>=0.8)"]
 
 [[package]]
 category = "main"
@@ -1880,7 +1881,7 @@ description = "JavaScript minifier."
 name = "jsmin"
 optional = false
 python-versions = "*"
-version = "2.2.2"
+version = "3.0.0"
 
 [[package]]
 category = "main"
@@ -2055,7 +2056,7 @@ description = "Inline Matplotlib backend for Jupyter"
 name = "matplotlib-inline"
 optional = false
 python-versions = ">=3.5"
-version = "0.1.2"
+version = "0.1.3"
 
 [package.dependencies]
 traitlets = "*"
@@ -2066,7 +2067,7 @@ description = "Reader for the MaxMind DB format"
 name = "maxminddb"
 optional = false
 python-versions = ">=3.6"
-version = "2.0.3"
+version = "2.1.0"
 
 [[package]]
 category = "main"
@@ -2660,7 +2661,7 @@ description = "Python client for Sentry (https://sentry.io)"
 name = "sentry-sdk"
 optional = false
 python-versions = "*"
-version = "1.3.1"
+version = "1.4.1"
 
 [package.dependencies]
 certifi = "*"
@@ -2997,7 +2998,7 @@ description = "HTTP library with thread-safe connection pooling, file post, and 
 name = "urllib3"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
-version = "1.26.6"
+version = "1.26.7"
 
 [package.extras]
 brotli = ["brotlipy (>=0.6.0)"]
@@ -3185,8 +3186,8 @@ alabaster = [
     {file = "alabaster-0.7.12.tar.gz", hash = "sha256:a661d72d58e6ea8a57f7a86e37d86716863ee5e92788398526d58b26a4e4dc02"},
 ]
 alembic = [
-    {file = "alembic-1.7.1-py3-none-any.whl", hash = "sha256:25f996b7408b11493d6a2d669fd9d2ff8d87883fe7434182bc7669d6caa526ab"},
-    {file = "alembic-1.7.1.tar.gz", hash = "sha256:aea964d3dcc9c205b8759e4e9c1c3935ea3afeee259bffd7ed8414f8085140fb"},
+    {file = "alembic-1.7.3-py3-none-any.whl", hash = "sha256:d0c580041f9f6487d5444df672a83da9be57398f39d6c1802bbedec6fefbeef6"},
+    {file = "alembic-1.7.3.tar.gz", hash = "sha256:bc5bdf03d1b9814ee4d72adc0b19df2123f6c50a60c1ea761733f3640feedb8d"},
 ]
 amqp = [
     {file = "amqp-5.0.6-py3-none-any.whl", hash = "sha256:493a2ac6788ce270a2f6a765b017299f60c1998f5a8617908ee9be082f7300fb"},
@@ -3235,8 +3236,8 @@ blinker = [
     {file = "blinker-1.4.tar.gz", hash = "sha256:471aee25f3992bd325afa3772f1063dbdbbca947a041b8b89466dc00d606f8b6"},
 ]
 build = [
-    {file = "build-0.6.1-py3-none-any.whl", hash = "sha256:59669d59404cd9ef3f6f425030f4a423743703d653960c536c79c032886dc125"},
-    {file = "build-0.6.1.tar.gz", hash = "sha256:cebb047236cb7da777ac3335a8b16bfc585db374fedf0f647f6ea0efd953f54d"},
+    {file = "build-0.7.0-py3-none-any.whl", hash = "sha256:21b7ebbd1b22499c4dac536abc7606696ea4d909fd755e00f09f3c0f2c05e3c8"},
+    {file = "build-0.7.0.tar.gz", hash = "sha256:1aaadcd69338252ade4f7ec1265e1a19184bf916d84c9b7df095f423948cb89f"},
 ]
 cached-property = [
     {file = "cached-property-1.5.2.tar.gz", hash = "sha256:9fa5755838eecbb2d234c3aa390bd80fbd3ac6b6869109bfc1b499f7bd89a130"},
@@ -3302,12 +3303,12 @@ cffi = [
     {file = "cffi-1.14.6.tar.gz", hash = "sha256:c9a875ce9d7fe32887784274dd533c57909b7b1dcadcc128a2ac21331a9765dd"},
 ]
 charset-normalizer = [
-    {file = "charset-normalizer-2.0.4.tar.gz", hash = "sha256:f23667ebe1084be45f6ae0538e4a5a865206544097e4e8bbcacf42cd02a348f3"},
-    {file = "charset_normalizer-2.0.4-py3-none-any.whl", hash = "sha256:0c8911edd15d19223366a194a513099a302055a962bca2cec0f54b8b63175d8b"},
+    {file = "charset-normalizer-2.0.6.tar.gz", hash = "sha256:5ec46d183433dcbd0ab716f2d7f29d8dee50505b3fdb40c6b985c7c4f5a3591f"},
+    {file = "charset_normalizer-2.0.6-py3-none-any.whl", hash = "sha256:5d209c0a931f215cee683b6445e2d77677e7e75e159f78def0db09d68fafcaa6"},
 ]
 check-manifest = [
-    {file = "check-manifest-0.46.tar.gz", hash = "sha256:5895e42a012989bdc51854a02c82c8d6898112a4ab11f2d7878200520b49d428"},
-    {file = "check_manifest-0.46-py3-none-any.whl", hash = "sha256:b59b0e7c7ed3946537677c9ab9b2c2cb7be9b1807fd40bc4dfc1eef31d42cff5"},
+    {file = "check-manifest-0.47.tar.gz", hash = "sha256:56dadd260a9c7d550b159796d2894b6d0bcc176a94cbc426d9bb93e5e48d12ce"},
+    {file = "check_manifest-0.47-py3-none-any.whl", hash = "sha256:365c94d65de4c927d9d8b505371d08ee19f9f369c86b9ac3db97c2754c827c95"},
 ]
 click = [
     {file = "click-7.1.2-py2.py3-none-any.whl", hash = "sha256:dacca89f4bfadd5de3d7489b7c8a566eee0d3676333fbb50030263894c38c0dc"},
@@ -3379,8 +3380,8 @@ cryptography = [
     {file = "cryptography-3.4.8.tar.gz", hash = "sha256:94cc5ed4ceaefcbe5bf38c8fba6a21fc1d365bb8fb826ea1688e3370b2e24a1c"},
 ]
 decorator = [
-    {file = "decorator-5.0.9-py3-none-any.whl", hash = "sha256:6e5c199c16f7a9f0e3a61a4a54b3d27e7dad0dbdde92b944426cb20914376323"},
-    {file = "decorator-5.0.9.tar.gz", hash = "sha256:72ecfba4320a893c53f9706bebb2d55c270c1e51a28789361aa93e4a21319ed5"},
+    {file = "decorator-5.1.0-py3-none-any.whl", hash = "sha256:7b12e7c3c6ab203a29e157335e9122cb03de9ab7264b137594103fd4a683b374"},
+    {file = "decorator-5.1.0.tar.gz", hash = "sha256:e59913af105b9860aa2c8d3272d9de5a56a4e608db9a2f167a8480b323d529a7"},
 ]
 dnspython = [
     {file = "dnspython-2.1.0-py3-none-any.whl", hash = "sha256:95d12f6ef0317118d2a1a6fc49aac65ffec7eb8087474158f42f26a639135216"},
@@ -3415,8 +3416,8 @@ email-validator = [
     {file = "email_validator-1.1.3.tar.gz", hash = "sha256:aa237a65f6f4da067119b7df3f13e89c25c051327b2b5b66dc075f33d62480d7"},
 ]
 flask = [
-    {file = "Flask-1.1.2-py2.py3-none-any.whl", hash = "sha256:8a4fdd8936eba2512e9c85df320a37e694c93945b33ef33c89946a340a238557"},
-    {file = "Flask-1.1.2.tar.gz", hash = "sha256:4efa1ae2d7c9865af48986de8aeb8504bf32c7f3d6fdc9353d34b21f4b127060"},
+    {file = "Flask-1.1.4-py2.py3-none-any.whl", hash = "sha256:c34f04500f2cbbea882b1acb02002ad6fe6b7ffa64a6164577995657f50aed22"},
+    {file = "Flask-1.1.4.tar.gz", hash = "sha256:0fbeb6180d383a9186d0d6ed954e0042ad9f18e0e8de088b2b419d526927d196"},
 ]
 flask-admin = [
     {file = "Flask-Admin-1.5.8.tar.gz", hash = "sha256:eb06a1f31b98881dee53a55c64faebd1990d6aac38826364b280df0b2679ff74"},
@@ -3603,8 +3604,8 @@ invenio-access = [
     {file = "invenio_access-1.4.2-py2.py3-none-any.whl", hash = "sha256:463cde5a24edab0c147ec7922372e6f46ac940409320e223334bf5f9e62e9d87"},
 ]
 invenio-accounts = [
-    {file = "invenio-accounts-1.4.4.tar.gz", hash = "sha256:70d1efea77f5bc6c623ff402ecf8e08ca07a6ebf253c6341cf89bb30289fa18e"},
-    {file = "invenio_accounts-1.4.4-py2.py3-none-any.whl", hash = "sha256:59ff381bbcb97e8c59453caa1d9d7e4aebeb6b44ee01363ae662e33c77dd4896"},
+    {file = "invenio-accounts-1.4.6.tar.gz", hash = "sha256:229f9f8c6e12aee79ca9dd85ffe3ae69745766ff3db56f1d2a009ceb6a5f6abd"},
+    {file = "invenio_accounts-1.4.6-py2.py3-none-any.whl", hash = "sha256:5c8eac965a1489d44b047e207199933e71e0cb28f4635031b1a27bd651a27585"},
 ]
 invenio-admin = [
     {file = "invenio-admin-1.3.0.tar.gz", hash = "sha256:59aa4cc7e41744eb5c55d37f24e7f8cc5cd4ab368f21b2a6fe4cb90a6a016f05"},
@@ -3639,8 +3640,8 @@ invenio-db = [
     {file = "invenio_db-1.0.9-py2.py3-none-any.whl", hash = "sha256:c8861a665af5cbb3645d4fde5cc0e04354a108a3d5b4cf2c3eee5d252da5d534"},
 ]
 invenio-formatter = [
-    {file = "invenio-formatter-1.1.1.tar.gz", hash = "sha256:575f983ea1c214071d23fd7a437ecd7dc991c545097502f5753e4a81d1f61728"},
-    {file = "invenio_formatter-1.1.1-py2.py3-none-any.whl", hash = "sha256:0278a1fb48edda87aecfbaf102bbccffb7bd8fe27a63d0ef1649fd43aaa16587"},
+    {file = "invenio-formatter-1.1.2.tar.gz", hash = "sha256:2b1091fb507cd21a9539e8ed96d007059bbb64059330b10bfc5231e6b2c81509"},
+    {file = "invenio_formatter-1.1.2-py2.py3-none-any.whl", hash = "sha256:a6ef4892d2c5acf6c55963258da3ce309633bd00de419219429af56e91230e4a"},
 ]
 invenio-i18n = [
     {file = "invenio-i18n-1.3.0.tar.gz", hash = "sha256:631ad500aa49df91815dbe3f38a8bc27a7d25ce3fad821aa159c82f60b02738f"},
@@ -3664,8 +3665,8 @@ invenio-mail = [
 ]
 invenio-oaiharvester = []
 invenio-oaiserver = [
-    {file = "invenio-oaiserver-1.2.1.tar.gz", hash = "sha256:b830344584e078c731da933f26da0e77b1409bb7827ab7030694dabe1d39aec3"},
-    {file = "invenio_oaiserver-1.2.1-py2.py3-none-any.whl", hash = "sha256:1337147b5b1819ad3e431be1f18bda1d0a598f85105e08b6db24900fa6563542"},
+    {file = "invenio-oaiserver-1.2.2.tar.gz", hash = "sha256:1d55b76ce2ae4a5928c95ff4ab61b6e2be40bd9ce37527406a2566167c431fbf"},
+    {file = "invenio_oaiserver-1.2.2-py2.py3-none-any.whl", hash = "sha256:e00eeb2895d9ba39bf2c23539847415c2fad298e3c2af165b406448b48cfa1d3"},
 ]
 invenio-oauth2server = [
     {file = "invenio-oauth2server-1.3.4.tar.gz", hash = "sha256:98fcebc98180746533968a6e4fe3ec72568eb442cde904d11d07067825b52759"},
@@ -3724,19 +3725,19 @@ isort = [
     {file = "isort-5.9.3.tar.gz", hash = "sha256:9c2ea1e62d871267b78307fe511c0838ba0da28698c5732d54e2790bf3ba9899"},
 ]
 itsdangerous = [
-    {file = "itsdangerous-2.0.1-py3-none-any.whl", hash = "sha256:5174094b9637652bdb841a3029700391451bd092ba3db90600dea710ba28e97c"},
-    {file = "itsdangerous-2.0.1.tar.gz", hash = "sha256:9e724d68fc22902a1435351f84c3fb8623f303fffcc566a4cb952df8c572cff0"},
+    {file = "itsdangerous-1.1.0-py2.py3-none-any.whl", hash = "sha256:b12271b2047cb23eeb98c8b5622e2e5c5e9abd9784a153e9d8ef9cb4dd09d749"},
+    {file = "itsdangerous-1.1.0.tar.gz", hash = "sha256:321b033d07f2a4136d3ec762eac9f16a10ccd60f53c0c91af90217ace7ba1f19"},
 ]
 jedi = [
     {file = "jedi-0.17.2-py2.py3-none-any.whl", hash = "sha256:98cc583fa0f2f8304968199b01b6b4b94f469a1f4a74c1560506ca2a211378b5"},
     {file = "jedi-0.17.2.tar.gz", hash = "sha256:86ed7d9b750603e4ba582ea8edc678657fb4007894a12bcf6f4bb97892f31d20"},
 ]
 jinja2 = [
-    {file = "Jinja2-3.0.1-py3-none-any.whl", hash = "sha256:1f06f2da51e7b56b8f238affdd6b4e2c61e39598a378cc49345bc1bd42a978a4"},
-    {file = "Jinja2-3.0.1.tar.gz", hash = "sha256:703f484b47a6af502e743c9122595cc812b0271f661722403114f71a79d0f5a4"},
+    {file = "Jinja2-2.11.3-py2.py3-none-any.whl", hash = "sha256:03e47ad063331dd6a3f04a43eddca8a966a26ba0c5b7207a9a9e4e08f1b29419"},
+    {file = "Jinja2-2.11.3.tar.gz", hash = "sha256:a6d58433de0ae800347cab1fa3043cebbabe8baa9d29e668f1c768cb87a333c6"},
 ]
 jsmin = [
-    {file = "jsmin-2.2.2.tar.gz", hash = "sha256:b6df99b2cd1c75d9d342e4335b535789b8da9107ec748212706ef7bbe5c2553b"},
+    {file = "jsmin-3.0.0.tar.gz", hash = "sha256:88fc1bd6033a47c5911dbcada7d279c7a8b7ad0841909590f6a742c20c4d2e08"},
 ]
 jsonpatch = [
     {file = "jsonpatch-1.32-py2.py3-none-any.whl", hash = "sha256:26ac385719ac9f54df8a2f0827bb8253aa3ea8ab7b3368457bcdb8c14595a397"},
@@ -3774,6 +3775,8 @@ lxml = [
     {file = "lxml-4.6.3-cp27-cp27m-win_amd64.whl", hash = "sha256:8157dadbb09a34a6bd95a50690595e1fa0af1a99445e2744110e3dca7831c4ee"},
     {file = "lxml-4.6.3-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:7728e05c35412ba36d3e9795ae8995e3c86958179c9770e65558ec3fdfd3724f"},
     {file = "lxml-4.6.3-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:4bff24dfeea62f2e56f5bab929b4428ae6caba2d1eea0c2d6eb618e30a71e6d4"},
+    {file = "lxml-4.6.3-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:74f7d8d439b18fa4c385f3f5dfd11144bb87c1da034a466c5b5577d23a1d9b51"},
+    {file = "lxml-4.6.3-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:f90ba11136bfdd25cae3951af8da2e95121c9b9b93727b1b896e3fa105b2f586"},
     {file = "lxml-4.6.3-cp35-cp35m-win32.whl", hash = "sha256:f2380a6376dfa090227b663f9678150ef27543483055cc327555fb592c5967e2"},
     {file = "lxml-4.6.3-cp35-cp35m-win_amd64.whl", hash = "sha256:c4f05c5a7c49d2fb70223d0d5bcfbe474cf928310ac9fa6a7c6dddc831d0b1d4"},
     {file = "lxml-4.6.3-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:d2e35d7bf1c1ac8c538f88d26b396e73dd81440d59c1ef8522e1ea77b345ede4"},
@@ -3800,6 +3803,7 @@ lxml = [
     {file = "lxml-4.6.3-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:884ab9b29feaca361f7f88d811b1eea9bfca36cf3da27768d28ad45c3ee6f969"},
     {file = "lxml-4.6.3-cp39-cp39-win32.whl", hash = "sha256:33bb934a044cf32157c12bfcfbb6649807da20aa92c062ef51903415c704704f"},
     {file = "lxml-4.6.3-cp39-cp39-win_amd64.whl", hash = "sha256:542d454665a3e277f76954418124d67516c5f88e51a900365ed54a9806122b83"},
+    {file = "lxml-4.6.3.tar.gz", hash = "sha256:39b78571b3b30645ac77b95f7c69d1bffc4cf8c3b157c435a34da72e78c82468"},
 ]
 mako = [
     {file = "Mako-1.1.5-py2.py3-none-any.whl", hash = "sha256:6804ee66a7f6a6416910463b00d76a7b25194cd27f1918500c5bd7be2a088a23"},
@@ -3846,11 +3850,11 @@ marshmallow = [
     {file = "marshmallow-3.13.0.tar.gz", hash = "sha256:c67929438fd73a2be92128caa0325b1b5ed8b626d91a094d2f7f2771bf1f1c0e"},
 ]
 matplotlib-inline = [
-    {file = "matplotlib-inline-0.1.2.tar.gz", hash = "sha256:f41d5ff73c9f5385775d5c0bc13b424535c8402fe70ea8210f93e11f3683993e"},
-    {file = "matplotlib_inline-0.1.2-py3-none-any.whl", hash = "sha256:5cf1176f554abb4fa98cb362aa2b55c500147e4bdbb07e3fda359143e1da0811"},
+    {file = "matplotlib-inline-0.1.3.tar.gz", hash = "sha256:a04bfba22e0d1395479f866853ec1ee28eea1485c1d69a6faf00dc3e24ff34ee"},
+    {file = "matplotlib_inline-0.1.3-py3-none-any.whl", hash = "sha256:aed605ba3b72462d64d475a21a9296f400a19c4f74a31b59103d2a99ffd5aa5c"},
 ]
 maxminddb = [
-    {file = "maxminddb-2.0.3.tar.gz", hash = "sha256:47e86a084dd814fac88c99ea34ba3278a74bc9de5a25f4b815b608798747c7dc"},
+    {file = "maxminddb-2.1.0.tar.gz", hash = "sha256:c47b8acba98d03b8c762684d899623c257976f3eb0c9d557ff865d20cddc9d6b"},
 ]
 maxminddb-geolite2 = [
     {file = "maxminddb-geolite2-2018.703.tar.gz", hash = "sha256:2bd118c5567f3a8323d6c5da23a6e6d52cfc09cd9987b54eb712cf6001a96e03"},
@@ -4148,8 +4152,8 @@ selenium = [
     {file = "selenium-3.141.0.tar.gz", hash = "sha256:deaf32b60ad91a4611b98d8002757f29e6f2c2d5fcaf202e1c9ad06d6772300d"},
 ]
 sentry-sdk = [
-    {file = "sentry-sdk-1.3.1.tar.gz", hash = "sha256:ebe99144fa9618d4b0e7617e7929b75acd905d258c3c779edcd34c0adfffe26c"},
-    {file = "sentry_sdk-1.3.1-py2.py3-none-any.whl", hash = "sha256:f33d34c886d0ba24c75ea8885a8b3a172358853c7cbde05979fc99c29ef7bc52"},
+    {file = "sentry-sdk-1.4.1.tar.gz", hash = "sha256:4297555ddc37c7136740e6b547b7d68f5bca0b4832f94ac097e5d531a4c77528"},
+    {file = "sentry_sdk-1.4.1-py2.py3-none-any.whl", hash = "sha256:ea04bc3be6eb082f34ff3f8f6380ea9c691766592298f3f975a435dafac6bf6a"},
 ]
 sickle = [
     {file = "Sickle-0.7.0-py3-none-any.whl", hash = "sha256:6ace7b1d1fc76571fe0dbfefc2c49e5e6c026e2d0dcaae521f4da21e98d4bc85"},
@@ -4320,8 +4324,8 @@ uritools = [
     {file = "uritools-3.0.2.tar.gz", hash = "sha256:28ffef82ce3b2793237d36e45aa7cde28dae6502f6a93fdbd05ede401520e279"},
 ]
 urllib3 = [
-    {file = "urllib3-1.26.6-py2.py3-none-any.whl", hash = "sha256:39fb8672126159acb139a7718dd10806104dec1e2f0f6c88aab05d17df10c8d4"},
-    {file = "urllib3-1.26.6.tar.gz", hash = "sha256:f57b4c16c62fa2760b7e3d97c35b255512fb6b59a259730f36ba32ce9f8e342f"},
+    {file = "urllib3-1.26.7-py2.py3-none-any.whl", hash = "sha256:c4fdf4019605b6e5423637e01bc9fe4daef873709a7973e195ceba0a62bbc844"},
+    {file = "urllib3-1.26.7.tar.gz", hash = "sha256:4987c65554f7a2dbf30c18fd48778ef124af6fab771a377103da0585e2336ece"},
 ]
 uwsgi = [
     {file = "uWSGI-2.0.19.1.tar.gz", hash = "sha256:faa85e053c0b1be4d5585b0858d3a511d2cd10201802e8676060fd0a109e5869"},

--- a/rero_mef/agents/gnd/views.py
+++ b/rero_mef/agents/gnd/views.py
@@ -15,12 +15,31 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Version information for RERO MEF.
+"""Agent GND views."""
 
-This file is imported by ``rero_mef.__init__``,
-and parsed by ``setup.py``.
-"""
+from flask import Blueprint, redirect, request, url_for
 
-from __future__ import absolute_import, print_function
+api_blueprint = Blueprint(
+    'api_gnd',
+    __name__,
+    url_prefix='/gnd'
+)
 
-__version__ = '0.7.2'
+
+@api_blueprint.route('')
+def redirect_idref_list():
+    """Redirect list to new address."""
+    return redirect(
+        url_for('invenio_records_rest.aidref_list', **request.args),
+        code=308
+    )
+
+
+@api_blueprint.route('/<pid>')
+def redirect_idref_item(pid):
+    """Redirect item to new address."""
+    return redirect(
+        url_for(
+            'invenio_records_rest.aidref_item', pid_value=pid, **request.args),
+        code=308
+    )

--- a/rero_mef/agents/idref/tasks.py
+++ b/rero_mef/agents/idref/tasks.py
@@ -44,10 +44,8 @@ class MySickle(Sickle):
                     and http_response.status_code in self.retry_status_codes:
                 retry_after = self.get_retry_after(http_response)
                 current_app.logger.warning(
-                    "HTTP {code}! Retrying after {after} seconds...".format(
-                        code=http_response.status_code,
-                        after=retry_after
-                    )
+                    f'HTTP {http_response.status_code}! '
+                    f'Retrying after {retry_after} seconds...'
                 )
                 time.sleep(retry_after)
                 http_response = self._request(kwargs)

--- a/rero_mef/agents/idref/views.py
+++ b/rero_mef/agents/idref/views.py
@@ -15,12 +15,31 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Version information for RERO MEF.
+"""Agent IdRef views."""
 
-This file is imported by ``rero_mef.__init__``,
-and parsed by ``setup.py``.
-"""
+from flask import Blueprint, redirect, request, url_for
 
-from __future__ import absolute_import, print_function
+api_blueprint = Blueprint(
+    'api_idref',
+    __name__,
+    url_prefix='/idref'
+)
 
-__version__ = '0.7.2'
+
+@api_blueprint.route('')
+def redirect_idref_list():
+    """Redirect list to new address."""
+    return redirect(
+        url_for('invenio_records_rest.aggnd_list', **request.args),
+        code=308
+    )
+
+
+@api_blueprint.route('/<pid>')
+def redirect_idref_item(pid):
+    """Redirect item to new address."""
+    return redirect(
+        url_for(
+            'invenio_records_rest.aggnd_item', pid_value=pid, **request.args),
+        code=308
+    )

--- a/rero_mef/agents/mef/jsonresolvers/mef_resolver.py
+++ b/rero_mef/agents/mef/jsonresolvers/mef_resolver.py
@@ -22,11 +22,11 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 import jsonresolver
 
-from ..api import MefRecord
+from ..api import AgentMefRecord
 from ....utils import get_host, resolve_record
 
 
-@jsonresolver.route('/api/mef/<path:path>', host=get_host())
+@jsonresolver.route('/api/agents/mef/<path:path>', host=get_host())
 def resolve_mef(path):
     """Resolve Mef records."""
-    return resolve_record(path, MefRecord)
+    return resolve_record(path, AgentMefRecord)

--- a/rero_mef/agents/mef/listner.py
+++ b/rero_mef/agents/mef/listner.py
@@ -17,7 +17,7 @@
 
 """Signals connector for MEF records."""
 
-from .api import MefSearch
+from .api import AgentMefSearch
 
 
 def enrich_mef_data(sender, json=None, record=None, index=None, doc_type=None,
@@ -29,15 +29,10 @@ def enrich_mef_data(sender, json=None, record=None, index=None, doc_type=None,
     :param index: The index in which the record will be indexed.
     :param doc_type: The doc_type for the record.
     """
-    if index.split('-')[0] == MefSearch.Meta.index:
+    if index.split('-')[0] == AgentMefSearch.Meta.index:
         sources = []
-        if 'rero' in json:
-            sources.append('rero')
-            json['type'] = json['rero']['bf:Agent']
-        if 'gnd' in json:
-            sources.append('gnd')
-            json['type'] = json['gnd']['bf:Agent']
-        if 'idref' in json:
-            sources.append('idref')
-            json['type'] = json['idref']['bf:Agent']
+        for agent in ['rero', 'gnd', 'idref']:
+            if agent in json and json[agent]:
+                sources.append(agent)
+                json['type'] = json[agent]['bf:Agent']
         json['sources'] = sources

--- a/rero_mef/agents/mef/views.py
+++ b/rero_mef/agents/mef/views.py
@@ -15,12 +15,31 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Version information for RERO MEF.
+"""Agent MEF views."""
 
-This file is imported by ``rero_mef.__init__``,
-and parsed by ``setup.py``.
-"""
+from flask import Blueprint, redirect, request, url_for
 
-from __future__ import absolute_import, print_function
+api_blueprint = Blueprint(
+    'api_mef',
+    __name__,
+    url_prefix='/mef'
+)
 
-__version__ = '0.7.2'
+
+@api_blueprint.route('')
+def redirect_idref_list():
+    """Redirect list to new address."""
+    return redirect(
+        url_for('invenio_records_rest.mef_list', **request.args),
+        code=308
+    )
+
+
+@api_blueprint.route('/<pid>')
+def redirect_idref_item(pid):
+    """Redirect item to new address."""
+    return redirect(
+        url_for(
+            'invenio_records_rest.mef_item', pid_value=pid, **request.args),
+        code=308
+    )

--- a/rero_mef/agents/rero/tasks.py
+++ b/rero_mef/agents/rero/tasks.py
@@ -34,14 +34,7 @@ def rero_get_record(id, verbose=False, debug=False):
     http://data.rero.ch/
     http://data.rero.ch/02-A000069866/marcxml
     """
-    base_url = 'http://data.rero.ch/02-'
-    query_id = '{id}'.format(id=id)
-    format = '/marcxml'
-    url = '{base_url}{query_id}{format}'.format(
-        base_url=base_url,
-        query_id=query_id,
-        format=format
-    )
+    url = f'http://data.rero.ch/02-{id}/marcxml'
     trans_record = None
     response = requests.get(url)
     if response.status_code == requests.codes.ok:
@@ -50,10 +43,10 @@ def rero_get_record(id, verbose=False, debug=False):
             if records:
                 trans_record = Transformation(records[0]).json
                 if verbose:
-                    click.echo('API-rero get: {id}'.format(id=id))
+                    click.echo(f'API-rero get: {id}')
         except Exception as err:
             if verbose:
-                click.echo('ERROR get rero record: {err}'.format(err=err))
+                click.echo(f'ERROR get rero record: {err}')
             if debug:
                 raise Exception(err)
     return trans_record

--- a/rero_mef/agents/rero/views.py
+++ b/rero_mef/agents/rero/views.py
@@ -15,12 +15,31 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Version information for RERO MEF.
+"""Agent RERO views."""
 
-This file is imported by ``rero_mef.__init__``,
-and parsed by ``setup.py``.
-"""
+from flask import Blueprint, redirect, request, url_for
 
-from __future__ import absolute_import, print_function
+api_blueprint = Blueprint(
+    'api_rero',
+    __name__,
+    url_prefix='/rero'
+)
 
-__version__ = '0.7.2'
+
+@api_blueprint.route('')
+def redirect_idref_list():
+    """Redirect list to new address."""
+    return redirect(
+        url_for('invenio_records_rest.agrero_list', **request.args),
+        code=308
+    )
+
+
+@api_blueprint.route('/<pid>')
+def redirect_idref_item(pid):
+    """Redirect item to new address."""
+    return redirect(
+        url_for(
+            'invenio_records_rest.agrero_item', pid_value=pid, **request.args),
+        code=308
+    )

--- a/rero_mef/agents/viaf/views.py
+++ b/rero_mef/agents/viaf/views.py
@@ -15,12 +15,31 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-"""Version information for RERO MEF.
+"""Agent VIAF views."""
 
-This file is imported by ``rero_mef.__init__``,
-and parsed by ``setup.py``.
-"""
+from flask import Blueprint, redirect, request, url_for
 
-from __future__ import absolute_import, print_function
+api_blueprint = Blueprint(
+    'api_viaf',
+    __name__,
+    url_prefix='/viaf'
+)
 
-__version__ = '0.7.2'
+
+@api_blueprint.route('')
+def redirect_idref_list():
+    """Redirect list to new address."""
+    return redirect(
+        url_for('invenio_records_rest.viaf_list', **request.args),
+        code=308
+    )
+
+
+@api_blueprint.route('/<pid>')
+def redirect_idref_item(pid):
+    """Redirect item to new address."""
+    return redirect(
+        url_for(
+            'invenio_records_rest.viaf_item', pid_value=pid, **request.args),
+        code=308
+    )

--- a/rero_mef/api.py
+++ b/rero_mef/api.py
@@ -128,7 +128,7 @@ class ReroMefRecord(Record):
                 # record has no changes
                 agent_action = Action.UPTODATE
                 return return_record, agent_action
-        return_record = self.update(
+        return_record = self.replace(
             data=data, dbcommit=dbcommit, reindex=reindex)
         agent_action = Action.UPDATE
         return return_record, agent_action
@@ -153,7 +153,7 @@ class ReroMefRecord(Record):
                 )
             else:
                 agent_action = Action.UPDATE
-                return_record = agent_record.update(
+                return_record = agent_record.replace(
                     data=data,
                     dbcommit=dbcommit,
                     reindex=reindex
@@ -196,10 +196,8 @@ class ReroMefRecord(Record):
                 return None
             except OperationalError:
                 get_record_error_count += 1
-                msg = 'Get record OperationalError: {count} {pid}'.format(
-                    count=get_record_error_count,
-                    pid=pid
-                )
+                msg = (f'Get record OperationalError: '
+                       f'{get_record_error_count} {pid}')
                 current_app.logger.error(msg)
                 db.session.rollback()
 
@@ -290,9 +288,7 @@ class ReroMefRecord(Record):
                 return count
             except OperationalError:
                 get_count_count += 1
-                msg = 'Get count OperationalError: {count}'.format(
-                    count=get_count_count,
-                )
+                msg = f'Get count OperationalError: {get_count_count}'
                 current_app.logger.error(msg)
                 db.session.rollback()
         raise OperationalError('Get count')
@@ -334,9 +330,7 @@ class ReroMefRecord(Record):
         new_data = deepcopy(data)
         pid = new_data.get('pid')
         if not pid:
-            raise ReroMefRecordError.PidMissing(
-                'missing pid={pid}'.format(pid=self.pid)
-            )
+            raise ReroMefRecordError.PidMissing(f'missing pid={self.pid}')
         self.clear()
         self = self.update(new_data, dbcommit=dbcommit, reindex=reindex)
         return self
@@ -380,7 +374,7 @@ class ReroMefRecord(Record):
         return metadata, identifier
 
 
-class ReroMefIndexer(RecordIndexer):
+class ReroIndexer(RecordIndexer):
     """Indexing class for mef."""
 
     index_error = {}
@@ -459,7 +453,7 @@ class ReroMefIndexer(RecordIndexer):
                 message.reject()
                 uid = payload.get('id', '???')
                 current_app.logger.error(
-                    "Failed to index record {uid}".format(uid=uid),
+                    f"Failed to index record {uid}",
                     exc_info=True)
 
     def _index_action(self, payload):
@@ -477,17 +471,13 @@ class ReroMefIndexer(RecordIndexer):
             except StatementError:
                 db.session.rollback()
                 get_record_error_count += 1
-                msg = 'INDEX ACTION StatementError: {count} {uid}'.format(
-                    count=get_record_error_count,
-                    uid=payload['id']
-                )
+                msg = ('INDEX ACTION StatementError: '
+                       f'{get_record_error_count} {payload["id"]}')
                 current_app.logger.error(msg)
             except OperationalError:
                 get_record_error_count += 1
-                msg = 'INDEX ACTION OperationalError: {count} {uid}'.format(
-                    count=get_record_error_count,
-                    uid=payload['id']
-                )
+                msg = ('INDEX ACTION OperationalError: '
+                       f'{get_record_error_count} {payload["id"]}')
                 current_app.logger.error(msg)
                 db.session.rollback()
             except Exception as err:

--- a/rero_mef/concepts/api.py
+++ b/rero_mef/concepts/api.py
@@ -19,7 +19,7 @@
 from flask import current_app
 from invenio_search import current_search
 
-from ..api import ReroMefIndexer, ReroMefRecord
+from ..api import ReroIndexer, ReroMefRecord
 
 
 class ConceptRecord(ReroMefRecord):
@@ -37,13 +37,11 @@ class ConceptRecord(ReroMefRecord):
     def update_indexes(cls):
         """Update indexes."""
         try:
-            index = 'concepts_{concept}'.format(concept=cls.concept)
+            index = 'fconcepts_{cls.concept}'
             current_search.flush_and_refresh(index=index)
         except Exception as err:
-            current_app.logger.error(
-                'ERROR flush and refresh: {err}'.format(err=err)
-            )
+            current_app.logger.error(f'ERROR flush and refresh: {err}')
 
 
-class ConceptIndexer(ReroMefIndexer):
+class ConceptIndexer(ReroIndexer):
     """Indexing class for agents."""

--- a/rero_mef/concepts/rero/api.py
+++ b/rero_mef/concepts/rero/api.py
@@ -57,6 +57,14 @@ class ConceptReroRecord(ConceptRecord):
     #     from .tasks import concepts_get_record
     #     return concepts_get_record(id=id, verbose=verbose)
 
+    def reindex(self, forceindex=False):
+        """Reindex record."""
+        if forceindex:
+            result = ConceptReroIndexer(version_type='external_gte').index(self)
+        else:
+            result = ConceptReroIndexer().index(self)
+        return result
+
 
 class ConceptReroIndexer(ConceptIndexer):
     """ConceptsIndexer."""

--- a/rero_mef/config.py
+++ b/rero_mef/config.py
@@ -220,9 +220,9 @@ RECORDS_REST_ENDPOINTS = dict(
         pid_type='mef',
         pid_minter='mef_id',
         pid_fetcher='mef_id',
-        search_class="rero_mef.agents.mef.api:MefSearch",
-        indexer_class="rero_mef.agents.mef.api:MefIndexer",
-        record_class="rero_mef.agents.mef.api:MefRecord",
+        search_class="rero_mef.agents.mef.api:AgentMefSearch",
+        indexer_class="rero_mef.agents.mef.api:AgentMefIndexer",
+        record_class="rero_mef.agents.mef.api:AgentMefRecord",
         search_index='mef',
         search_type=None,
         record_serializers={
@@ -234,9 +234,9 @@ RECORDS_REST_ENDPOINTS = dict(
                                  ':json_v1_search'),
         },
         search_factory_imp='rero_mef.query:and_search_factory',
-        list_route='/mef/',
-        item_route=('/mef/<pid(mef, record_class='
-                    '"rero_mef.agents.mef.api:MefRecord"):pid_value>'),
+        list_route='/agents/mef/',
+        item_route=('agents//mef/<pid(mef, record_class='
+                    '"rero_mef.agents.mef.api:AgentMefRecord"):pid_value>'),
         default_media_type='application/json',
         max_result_window=MAX_RESULT_WINDOW,
         error_handlers=dict(),
@@ -245,9 +245,9 @@ RECORDS_REST_ENDPOINTS = dict(
         pid_type='viaf',
         pid_minter='viaf_id',
         pid_fetcher='viaf_id',
-        search_class="rero_mef.agents.viaf.api:ViafSearch",
-        indexer_class="rero_mef.agents.viaf.api:ViafIndexer",
-        record_class="rero_mef.agents.viaf.api:ViafRecord",
+        search_class="rero_mef.agents.viaf.api:AgentViafSearch",
+        indexer_class="rero_mef.agents.viaf.api:AgentViafIndexer",
+        record_class="rero_mef.agents.viaf.api:AgentViafRecord",
         search_index='viaf',
         search_type=None,
         record_serializers={
@@ -259,9 +259,9 @@ RECORDS_REST_ENDPOINTS = dict(
                                  ':json_v1_search'),
         },
         search_factory_imp='rero_mef.query:and_search_factory',
-        list_route='/viaf/',
-        item_route=('/viaf/<pid(viaf, record_class='
-                    '"rero_mef.agents.viaf.api:ViafRecord"):pid_value>'),
+        list_route='/agents/viaf/',
+        item_route=('/agents/viaf/<pid(viaf, record_class='
+                    '"rero_mef.agents.viaf.api:AgentViafRecord"):pid_value>'),
         default_media_type='application/json',
         max_result_window=MAX_RESULT_WINDOW,
         error_handlers=dict(),
@@ -284,8 +284,8 @@ RECORDS_REST_ENDPOINTS = dict(
                                  ':json_v1_search'),
         },
         search_factory_imp='rero_mef.query:and_search_factory',
-        list_route='/gnd/',
-        item_route=('/gnd/<pid(aggnd, record_class='
+        list_route='/agents/gnd/',
+        item_route=('/agents/gnd/<pid(aggnd, record_class='
                     '"rero_mef.agents.gnd.api:AgentGndRecord"):pid_value>'),
         default_media_type='application/json',
         max_result_window=MAX_RESULT_WINDOW,
@@ -309,9 +309,10 @@ RECORDS_REST_ENDPOINTS = dict(
                                  ':json_v1_search'),
         },
         search_factory_imp='rero_mef.query:and_search_factory',
-        list_route='/idref/',
-        item_route=('/idref/<pid(aidref, record_class='
-                    '"rero_mef.agents.idref.api:AgentIdrefRecord"):pid_value>'),
+        list_route='/agents/idref/',
+        item_route=(
+            '/agents/idref/<pid(aidref, record_class='
+            '"rero_mef.agents.idref.api:AgentIdrefRecord"):pid_value>'),
         default_media_type='application/json',
         max_result_window=MAX_RESULT_WINDOW,
         error_handlers=dict()
@@ -334,8 +335,8 @@ RECORDS_REST_ENDPOINTS = dict(
                                  ':json_v1_search'),
         },
         search_factory_imp='rero_mef.query:and_search_factory',
-        list_route='/rero/',
-        item_route=('/rero/<pid(agrero, record_class='
+        list_route='/agents/rero/',
+        item_route=('/agents/rero/<pid(agrero, record_class='
                     '"rero_mef.agents.rero.api:AgentReroRecord"):pid_value>'),
         default_media_type='application/json',
         max_result_window=MAX_RESULT_WINDOW,
@@ -360,8 +361,9 @@ RECORDS_REST_ENDPOINTS = dict(
         },
         search_factory_imp='rero_mef.query:and_search_factory',
         list_route='/concepts/rero/',
-        item_route=('/concepts/rero/<pid(corero, record_class='
-                    '"rero_mef.concepts.rero.api:ConceptReroRecord"):pid_value>'),
+        item_route=(
+            '/concepts/rero/<pid(corero, record_class='
+            '"rero_mef.concepts.rero.api:ConceptReroRecord"):pid_value>'),
         default_media_type='application/json',
         max_result_window=MAX_RESULT_WINDOW,
         error_handlers=dict(),

--- a/rero_mef/marctojson/do_gnd_agent.py
+++ b/rero_mef/marctojson/do_gnd_agent.py
@@ -155,12 +155,8 @@ class Transformation(object):
             """Format date from field 100."""
             date_formated = date_str
             if len(date_str) == 8:
-                date_data = {
-                    'year': date_str[0:4],
-                    'month': date_str[4:6],
-                    'day': date_str[6:8]
-                }
-                date_formated = '{year}-{month}-{day}'.format(**date_data)
+                date_formated = \
+                    f'{date_str[0:4]}-{date_str[4:6]}-{date_str[6:8]}'
             elif len(date_str) == 4:
                 date_formated = date_str[0:4]
             return date_formated

--- a/rero_mef/marctojson/do_idref_agent.py
+++ b/rero_mef/marctojson/do_idref_agent.py
@@ -66,10 +66,7 @@ def get_language_script(field):
         test = languages[language][script_code]
     except Exception:
         script_code = 'latn'
-    return '{language}-{script_code}'.format(
-        language=language,
-        script_code=script_code
-    )
+    return f'{language}-{script_code}'
 
 
 def build_language_string_list_from_fields(

--- a/rero_mef/marctojson/do_rero_agent.py
+++ b/rero_mef/marctojson/do_rero_agent.py
@@ -57,8 +57,7 @@ class Transformation(object):
         field_035 = self.marc['035']
         if field_035 and field_035['a']:
             pid = field_035['a']
-            identifier = 'http://data.rero.ch/02-{pid}'.format(
-                pid=pid)
+            identifier = f'http://data.rero.ch/02-{pid}'
             self.json_dict['pid'] = pid
             self.json_dict['identifier'] = identifier
 
@@ -72,12 +71,8 @@ class Transformation(object):
             """DocString."""
             date_formated = date_str
             if len(date_str) == 8:
-                date_data = {
-                    'year': date_str[0:4],
-                    'month': date_str[4:6],
-                    'day': date_str[6:8]
-                }
-                date_formated = '{year}-{month}-{day}'.format(**date_data)
+                date_formated = \
+                    f'{date_str[0:4]}-{date_str[4:6]}-{date_str[6:8]}'
             elif len(date_str) == 4:
                 date_formated = date_str[0:4]
             return date_formated

--- a/rero_mef/marctojson/helper.py
+++ b/rero_mef/marctojson/helper.py
@@ -1323,7 +1323,7 @@ def nice_record(record, ctrl=False):
     leader = record.leader
     if ctrl:
         leader = replace_ctrl(leader)
-    nice = 'ldr: {leader}'.format(leader=leader)
+    nice = f'ldr: {leader}'
     for field in record:
         nice += '%s: %s' % (field.tag, nice_marc_field(field, ctrl)) + '\n'
     return nice

--- a/rero_mef/query.py
+++ b/rero_mef/query.py
@@ -47,7 +47,7 @@ def and_search_factory(self, search, query_parser=None):
         search = search.query(query_parser(query_string))
     except SyntaxError:
         current_app.logger.debug(
-            'Failed parsing query: {0}'.format(request.values.get('q', '')),
+            f'Failed parsing query: {request.values.get("q", "")}',
             exc_info=True,
         )
         raise InvalidQueryRESTError()
@@ -59,4 +59,10 @@ def and_search_factory(self, search, query_parser=None):
         urlkwargs.add(key, value)
 
     urlkwargs.add('q', query_string)
+
+    # include deleted
+    deleted = request.args.get('deleted')
+    if not deleted:
+        search = search.filter('bool', must_not=[Q('exists', field='deleted')])
+
     return search, urlkwargs

--- a/setup.py
+++ b/setup.py
@@ -125,6 +125,13 @@ setup(
             'agents_rero = rero_mef.agents.rero.jsonresolvers.rero_resolver',
             'concepts_rero = rero_mef.concepts.rero.jsonresolvers.rero_resolver',
         ],
+        'invenio_base.api_blueprints': [
+            'api_agents_mef = rero_mef.agents.mef.views:api_blueprint',
+            'api_agents_viaf = rero_mef.agents.viaf.views:api_blueprint',
+            'api_agents_gnd = rero_mef.agents.gnd.views:api_blueprint',
+            'api_agents_idref = rero_mef.agents.idref.views:api_blueprint',
+            'api_agents_rero = rero_mef.agents.rero.views:api_blueprint'
+        ],
         'flask.commands': [
             'fixtures = rero_mef.cli:fixtures',
             'utils = rero_mef.cli:utils',

--- a/tests/agents/test_agents_api.py
+++ b/tests/agents/test_agents_api.py
@@ -20,16 +20,16 @@
 from rero_mef.agents.gnd.api import AgentGndRecord
 from rero_mef.agents.idref.api import AgentIdrefRecord
 from rero_mef.agents.rero.api import AgentReroRecord
-from rero_mef.agents.viaf.api import ViafRecord
+from rero_mef.agents.viaf.api import AgentViafRecord
 
 
 def test_create_agent_record_with_viaf_links(
         app, viaf_record, gnd_record, rero_record, idref_record):
     """Test create agent record with viaf links."""
-    returned_record, action = ViafRecord.create_or_update(
+    returned_record, action = AgentViafRecord.create_or_update(
         viaf_record, dbcommit=True, reindex=True
     )
-    ViafRecord.update_indexes()
+    AgentViafRecord.update_indexes()
     assert action.name == 'CREATE'
     assert returned_record['pid'] == '66739143'
     assert returned_record['gnd_pid'] == '12391664X'

--- a/tests/agents/test_agents_api_updates.py
+++ b/tests/agents/test_agents_api_updates.py
@@ -21,13 +21,13 @@ import mock
 
 from rero_mef.agents.gnd.api import AgentGndRecord
 from rero_mef.agents.idref.api import AgentIdrefRecord
-from rero_mef.agents.mef.api import MefRecord
+from rero_mef.agents.mef.api import AgentMefRecord
 from rero_mef.agents.rero.api import AgentReroRecord
-from rero_mef.agents.viaf.api import ViafRecord
+from rero_mef.agents.viaf.api import AgentViafRecord
 
 
 @mock.patch(
-    'rero_mef.agents.viaf.api.ViafRecord.get_online_viaf_record')
+    'rero_mef.agents.viaf.api.AgentViafRecord.get_online_viaf_record')
 def test_create_agent_updates(mock_get, app, gnd_record, rero_record,
                               idref_record):
     """Test create agent record with viaf links."""
@@ -38,8 +38,8 @@ def test_create_agent_updates(mock_get, app, gnd_record, rero_record,
         'gnd_pid': '100769527xxx'
     }
     # create first record no viaf and mef records exist
-    assert MefRecord.count() == 0
-    assert ViafRecord.count() == 0
+    assert AgentMefRecord.count() == 0
+    assert AgentViafRecord.count() == 0
     record, action, m_record, m_action, v_record, online = \
         AgentIdrefRecord.create_or_update_agent_mef_viaf(
             data=idref_record,
@@ -49,18 +49,18 @@ def test_create_agent_updates(mock_get, app, gnd_record, rero_record,
         )
     assert action.name == 'CREATE'
     assert record['pid'] == '069774331'
-    assert MefRecord.count() == 1
-    assert ViafRecord.count() == 1
+    assert AgentMefRecord.count() == 1
+    assert AgentViafRecord.count() == 1
     assert online
 
     # we should have a mef and viaf record now
-    mef_pid = list(MefRecord.get_all_pids())[-1]
-    mef_record = MefRecord.get_record_by_pid(mef_pid)
+    mef_pid = list(AgentMefRecord.get_all_pids())[-1]
+    mef_record = AgentMefRecord.get_record_by_pid(mef_pid)
     assert mef_record.get('pid') == '1'
     assert mef_record.get('viaf_pid') == '37268949'
     assert 'idref' in mef_record
-    viaf_pid = list(ViafRecord.get_all_pids())[-1]
-    viaf_record = ViafRecord.get_record_by_pid(viaf_pid)
+    viaf_pid = list(AgentViafRecord.get_all_pids())[-1]
+    viaf_record = AgentViafRecord.get_record_by_pid(viaf_pid)
     assert viaf_record.get('pid') == '37268949'
     assert viaf_record.get('idref_pid') == '069774331'
 
@@ -79,13 +79,13 @@ def test_create_agent_updates(mock_get, app, gnd_record, rero_record,
             reindex=True,
             online=True
         )
-    mef_pid = list(MefRecord.get_all_pids())[-1]
-    mef_record = MefRecord.get_record_by_pid(mef_pid)
+    mef_pid = list(AgentMefRecord.get_all_pids())[-1]
+    mef_record = AgentMefRecord.get_record_by_pid(mef_pid)
     assert mef_record.get('pid') == '2'
     assert mef_record.get('viaf_pid') == '66739143'
     assert 'gnd' in mef_record
-    viaf_pid = list(ViafRecord.get_all_pids())[-1]
-    viaf_record = ViafRecord.get_record_by_pid(viaf_pid)
+    viaf_pid = list(AgentViafRecord.get_all_pids())[-1]
+    viaf_record = AgentViafRecord.get_record_by_pid(viaf_pid)
     assert viaf_record.get('pid') == '66739143'
     assert viaf_record.get('gnd_pid') == '12391664X'
 
@@ -97,17 +97,17 @@ def test_create_agent_updates(mock_get, app, gnd_record, rero_record,
             online=True
         )
 
-    mef_pid = list(MefRecord.get_all_pids())[-1]
-    mef_record = MefRecord.get_record_by_pid(mef_pid)
+    mef_pid = list(AgentMefRecord.get_all_pids())[-1]
+    mef_record = AgentMefRecord.get_record_by_pid(mef_pid)
     assert mef_record.get('pid') == '2'
     assert mef_record.get('viaf_pid') == '66739143'
     assert 'rero' in mef_record
-    viaf_pid = list(ViafRecord.get_all_pids())[-1]
-    viaf_record = ViafRecord.get_record_by_pid(viaf_pid)
+    viaf_pid = list(AgentViafRecord.get_all_pids())[-1]
+    viaf_record = AgentViafRecord.get_record_by_pid(viaf_pid)
     assert viaf_record.get('pid') == '66739143'
     assert viaf_record.get('rero_pid') == 'A023655346'
 
-    mef_record = MefRecord.get_mef_by_viaf_pid(viaf_pid)
+    mef_record = AgentMefRecord.get_mef_by_viaf_pid(viaf_pid)
     assert mef_record == {
         'pid': '2',
         'viaf_pid': '66739143',
@@ -125,8 +125,8 @@ def test_create_agent_updates(mock_get, app, gnd_record, rero_record,
     }
     mock_get.return_value = new_viaf_record
     rec, msg = viaf_record.delete(dbcommit=True, delindex=True, online=True)
-    assert ViafRecord.get_record_by_pid(new_viaf_pid) == new_viaf_record
-    mef_record = MefRecord.get_mef_by_viaf_pid(new_viaf_pid)
+    assert AgentViafRecord.get_record_by_pid(new_viaf_pid) == new_viaf_record
+    mef_record = AgentMefRecord.get_mef_by_viaf_pid(new_viaf_pid)
     assert mef_record == {
         'viaf_pid': 'xxxxxxxx',
         'gnd': {'$ref': 'https://mef.rero.ch/api/gnd/12391664X'},

--- a/tests/agents/test_ref_resolver.py
+++ b/tests/agents/test_ref_resolver.py
@@ -19,9 +19,9 @@
 
 from rero_mef.agents.gnd.api import AgentGndRecord
 from rero_mef.agents.idref.api import AgentIdrefRecord
-from rero_mef.agents.mef.api import MefRecord
+from rero_mef.agents.mef.api import AgentMefRecord
 from rero_mef.agents.rero.api import AgentReroRecord
-from rero_mef.agents.viaf.api import ViafRecord
+from rero_mef.agents.viaf.api import AgentViafRecord
 
 
 def test_ref_resolvers(
@@ -29,7 +29,7 @@ def test_ref_resolvers(
     """Test ref resolvers."""
 
     # VIAF record
-    record, action = ViafRecord.create_or_update(
+    record, action = AgentViafRecord.create_or_update(
         data=viaf_record,
         dbcommit=True,
         reindex=True
@@ -67,7 +67,7 @@ def test_ref_resolvers(
     idref_pid = record.get('pid')
 
     # MEF record
-    mef_rec_resolved = MefRecord.get_mef_by_viaf_pid(
+    mef_rec_resolved = AgentMefRecord.get_mef_by_viaf_pid(
         viaf_pid=viaf_pid
     )
     mef_rec_resolved = mef_rec_resolved.replace_refs()

--- a/tests/agents/test_signals.py
+++ b/tests/agents/test_signals.py
@@ -18,13 +18,13 @@
 """Test signals."""
 
 from rero_mef.agents.gnd.api import AgentGndRecord
-from rero_mef.agents.mef.api import MefSearch
-from rero_mef.agents.viaf.api import ViafRecord
+from rero_mef.agents.mef.api import AgentMefSearch
+from rero_mef.agents.viaf.api import AgentViafRecord
 
 
 def test_create_mef_from_agent_with_viaf_links(app, viaf_record, gnd_record):
     """Test create MEF record from agent with viaf links."""
-    v_record, action = ViafRecord.create_or_update(
+    v_record, action = AgentViafRecord.create_or_update(
         viaf_record, dbcommit=True, reindex=True
     )
     assert action.name == 'CREATE'
@@ -43,7 +43,7 @@ def test_create_mef_from_agent_with_viaf_links(app, viaf_record, gnd_record):
     assert action.name == 'CREATE'
     assert record['pid'] == '12391664X'
 
-    query = MefSearch(). \
+    query = AgentMefSearch(). \
         filter('term', gnd__pid='12391664X'). \
         source('sources').scan()
     assert next(query).sources == ['gnd']


### PR DESCRIPTION
* Renames MefRecord to AgentMefRecord, MefSearch to AgentMefSearch and MefIndexer to AgentMefIndexer.
* Renames ViafRecord to AgentViafRecord, ViafSearch to AgentViafSearch and MefIndexer to AgentViafIndexer.
* Replaces `format` functions with `f` strings.
* Implements JsonWriter.

Co-Authored-by: Peter Weber <peter.weber@rero.ch>