### PR TITLE
ci(release): bump version.py on release and pin invenio-search-ui

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,8 @@ dependencies = [
     "invenio-records-rest>=3.0.0",
     "invenio-records-ui>=2.0.0",
     "invenio-records>=4.0.0",
-    "invenio-search-ui>=4.0.0",
+    # Remove upper pin when https://github.com/inveniosoftware/invenio-search-ui/issues/254 is fixed
+    "invenio-search-ui>=4.0.0,<5.0.0",
     "python-dotenv >=0.13.0",
     ## MEF specific python modules
     "PyYAML>=5.3.1",
@@ -242,6 +243,7 @@ help = "Generate changelog and bump version locally (does not push, tag, or comm
 
 [tool.semantic_release]
 version_toml = ["pyproject.toml:project.version"]
+version_variables = ["rero_mef/version.py:__version__"]
 tag_format = "v{version}"
 commit_message = "chore(release): v{version}"
 build_command = """


### PR DESCRIPTION
- add version_variables so semantic-release also updates rero_mef/version.py:__version__ alongside pyproject.toml
- cap invenio-search-ui below 5.0.0 until inveniosoftware/invenio-search-ui#254 is fixed