### PR TITLE
fix(mef): resolve redirects via any linked source, not just one

### DIFF
--- a/rero_mef/agents/mef/api.py
+++ b/rero_mef/agents/mef/api.py
@@ -128,39 +128,6 @@ class AgentMefRecord(EntityMefRecord):
         """
         return get_all_missing_viaf_pids(verbose=verbose)
 
-    @classmethod
-    def get_latest(cls, pid_type, pid, _visited=None):
-        """Get latest Mef record for pid_type and pid.
-
-        :param pid_type: pid type to use.
-        :param pid: pid to use.
-        :param _visited: set of already-seen pids used to break redirect cycles.
-        :returns: latest record.
-        """
-        visited = _visited or set()
-        if pid in visited:
-            return {}
-        visited.add(pid)
-        search = AgentMefSearch().filter({"term": {f"{pid_type}.pid": pid}})
-        if search.count() > 0:
-            data = next(search.scan()).to_dict()
-            new_pid = None
-            if relation_pid := data.get(pid_type, {}).get("relation_pid"):
-                if relation_pid["type"] == "redirect_to":
-                    new_pid = relation_pid["value"]
-            elif pid_type == "idref":
-                # Find new pid from redirect_pid redirect_from
-                search = AgentMefSearch().filter("term", idref__relation_pid__value=pid)
-                if search.count() > 0:
-                    new_data = next(search.scan()).to_dict()
-                    new_pid = new_data.get("idref", {}).get("pid")
-            return (
-                cls.get_latest(pid_type=pid_type, pid=new_pid, _visited=visited)
-                if new_pid
-                else data
-            )
-        return {}
-
 
 class AgentMefIndexer(EntityIndexer):
     """Agent MEF indexer."""

--- a/rero_mef/api_mef.py
+++ b/rero_mef/api_mef.py
@@ -214,6 +214,69 @@ class EntityMefRecord(EntityRecord):
         deleted = cls.get_deleted(missing_pids, from_date)
         return generate(search, deleted)
 
+    @classmethod
+    def _find_redirect_target(cls, data):
+        """Find a newer (pid_type, pid) that the MEF record *data* redirects to.
+
+        Checks every source linked to *data*, not just one -- a MEF record can
+        be superseded via a different source than the one it was looked up by
+        (e.g. its IDREF source moved on while its GND source stayed put).
+        Handles both redirect conventions:
+
+        - ``redirect_to`` on the source itself (GND: the pointer is on the old
+          record).
+        - ``redirect_from`` on another record pointing back at this one
+          (IDREF: the pointer is on the new record, found via reverse lookup).
+
+        :param data: A MEF record dict with resolved source sub-documents.
+        :returns: (pid_type, pid) tuple, or None if no redirect target is found.
+        """
+        for source in cls.entities:
+            source_data = data.get(source)
+            if not isinstance(source_data, dict):
+                continue
+            if relation_pid := source_data.get("relation_pid"):
+                if relation_pid.get("type") == "redirect_to" and (
+                    value := relation_pid.get("value")
+                ):
+                    return source, value
+            if source_pid := source_data.get("pid"):
+                reverse = cls.search().filter(
+                    "term", **{f"{source}__relation_pid__value": source_pid}
+                )
+                for hit in reverse.scan():
+                    reverse_data = hit.to_dict()
+                    reverse_rel = reverse_data.get(source, {}).get("relation_pid", {})
+                    if reverse_rel.get("type") == "redirect_from" and (
+                        new_pid := reverse_data.get(source, {}).get("pid")
+                    ):
+                        return source, new_pid
+        return None
+
+    @classmethod
+    def get_latest(cls, pid_type, pid, _visited=None):
+        """Get latest Mef record for pid_type and pid.
+
+        :param pid_type: pid type to use for the initial lookup.
+        :param pid: pid to use for the initial lookup.
+        :param _visited: set of already-seen (pid_type, pid) pairs used to
+            break redirect cycles.
+        :returns: latest record.
+        """
+        visited = _visited or set()
+        key = (pid_type, pid)
+        if key in visited:
+            return {}
+        visited.add(key)
+        search = cls.search().filter({"term": {f"{pid_type}.pid": pid}})
+        if search.count() == 0:
+            return {}
+        data = next(search.scan()).to_dict()
+        if target := cls._find_redirect_target(data):
+            new_pid_type, new_pid = target
+            return cls.get_latest(pid_type=new_pid_type, pid=new_pid, _visited=visited)
+        return data
+
     def delete_ref(self, record, dbcommit=False, reindex=False):
         """Delete $ref from record.
 

--- a/rero_mef/concepts/mef/api.py
+++ b/rero_mef/concepts/mef/api.py
@@ -139,41 +139,6 @@ class ConceptMefRecord(EntityMefRecord):
             data["sources"] = my_sources
         return data
 
-    @classmethod
-    def get_latest(cls, pid_type, pid, _visited=None):
-        """Get latest Mef record for pid_type and pid.
-
-        :param pid_type: pid type to use.
-        :param pid: pid to use.
-        :param _visited: set of already-seen pids used to break redirect cycles.
-        :returns: latest record.
-        """
-        visited = _visited or set()
-        if pid in visited:
-            return {}
-        visited.add(pid)
-        search = ConceptMefSearch().filter({"term": {f"{pid_type}.pid": pid}})
-        if search.count() > 0:
-            data = next(search.scan()).to_dict()
-            new_pid = None
-            if relation_pid := data.get(pid_type, {}).get("relation_pid"):
-                if relation_pid["type"] == "redirect_to":
-                    new_pid = relation_pid["value"]
-            elif pid_type == "idref":
-                # Find new pid from redirect_pid redirect_from
-                search = ConceptMefSearch().filter(
-                    "term", idref__relation_pid__value=pid
-                )
-                if search.count() > 0:
-                    new_data = next(search.scan()).to_dict()
-                    new_pid = new_data.get("idref", {}).get("pid")
-            return (
-                cls.get_latest(pid_type=pid_type, pid=new_pid, _visited=visited)
-                if new_pid
-                else data
-            )
-        return {}
-
 
 class ConceptMefIndexer(EntityIndexer):
     """Concept MEF indexer."""

--- a/rero_mef/places/mef/api.py
+++ b/rero_mef/places/mef/api.py
@@ -117,39 +117,6 @@ class PlaceMefRecord(EntityMefRecord):
             data["sources"] = my_sources
         return data
 
-    @classmethod
-    def get_latest(cls, pid_type, pid, _visited=None):
-        """Get latest Mef record for pid_type and pid.
-
-        :param pid_type: pid type to use.
-        :param pid: pid to use.
-        :param _visited: set of already-seen pids used to break redirect cycles.
-        :returns: latest record.
-        """
-        visited = _visited or set()
-        if pid in visited:
-            return {}
-        visited.add(pid)
-        search = PlaceMefSearch().filter({"term": {f"{pid_type}.pid": pid}})
-        if search.count() > 0:
-            data = next(search.scan()).to_dict()
-            new_pid = None
-            if relation_pid := data.get(pid_type, {}).get("relation_pid"):
-                if relation_pid["type"] == "redirect_to":
-                    new_pid = relation_pid["value"]
-            elif pid_type == "idref":
-                # Find new pid from redirect_pid redirect_from
-                search = PlaceMefSearch().filter("term", idref__relation_pid__value=pid)
-                if search.count() > 0:
-                    new_data = next(search.scan()).to_dict()
-                    new_pid = new_data.get("idref", {}).get("pid")
-            return (
-                cls.get_latest(pid_type=pid_type, pid=new_pid, _visited=visited)
-                if new_pid
-                else data
-            )
-        return {}
-
 
 class PlaceMefIndexer(EntityIndexer):
     """Place MEF indexer."""

--- a/rero_mef/theme/views.py
+++ b/rero_mef/theme/views.py
@@ -281,16 +281,67 @@ def _relation_pid_detail_url(entity_type, rel, record_cls, src):
     """
     if not rel or not (target := rel.get("value")):
         return None, None
-    pids = record_cls.get_mef(target, src, pid_only=True)
-    if pids:
+    if pids := record_cls.get_mef(target, src, pid_only=True):
         return url_for(_DETAIL_ENDPOINT[entity_type], pid_value=pids[0]), None
     for other_type, other_cls in _ENTITY_DETAIL_CONFIG.items():
         if other_type == entity_type:
             continue
-        pids = other_cls["record_cls"].get_mef(target, src, pid_only=True)
-        if pids:
+        if pids := other_cls["record_cls"].get_mef(target, src, pid_only=True):
             return None, url_for(_DETAIL_ENDPOINT[other_type], pid_value=pids[0])
     return None, None
+
+
+def _reverse_relation_urls(record_cls, entity_type, src, src_pid):
+    """Search for records whose ``relation_pid`` points at (src, src_pid).
+
+    Covers the case where the pointer only exists on the other side of the
+    pair (GND puts it on the old record, IDREF puts it on the new one), so
+    whichever record you're viewing may have no ``relation_pid`` of its own.
+
+    :returns: (older_url, latest_url) tuple; either or both may be None.
+    """
+    older_url = None
+    latest_url = None
+    for hit in (
+        record_cls.search()
+        .filter("term", **{f"{src}__relation_pid__value": src_pid})
+        .scan()
+    ):
+        hit_src = hit.to_dict().get(src, {})
+        hit_rel_type = hit_src.get("relation_pid", {}).get("type")
+        hit_src_pid = hit_src.get("pid")
+        if not hit_src_pid:
+            continue
+        if not older_url and hit_rel_type == "redirect_to":
+            older_url = url_for(
+                _OLDER_ENDPOINT[entity_type], pid_type=src, pid=hit_src_pid
+            )
+        elif not latest_url and hit_rel_type == "redirect_from":
+            latest_url = url_for(
+                _LATEST_ENDPOINT[entity_type], pid_type=src, pid=hit_src_pid
+            )
+        if older_url and latest_url:
+            break
+    return older_url, latest_url
+
+
+def _own_relation_url(record_cls, entity_type, src, rel):
+    """Resolve a source sub-document's own ``relation_pid`` to a nav URL.
+
+    :param rel: The ``relation_pid`` dict from the source sub-document, or None.
+    :returns: (older_url, latest_url) tuple; both None if ``rel`` is absent,
+        malformed, or its target doesn't resolve to a MEF record.
+    """
+    if not rel or not (rel_value := rel.get("value")):
+        return None, None
+    rel_type = rel.get("type")
+    if rel_type not in ("redirect_to", "redirect_from"):
+        return None, None
+    if not record_cls.get_mef(rel_value, src, pid_only=True):
+        return None, None
+    if rel_type == "redirect_to":
+        return None, url_for(_LATEST_ENDPOINT[entity_type], pid_type=src, pid=rel_value)
+    return url_for(_OLDER_ENDPOINT[entity_type], pid_type=src, pid=rel_value), None
 
 
 def _compute_nav_urls(entity_type, record_cls, entities, resolved):
@@ -299,8 +350,8 @@ def _compute_nav_urls(entity_type, record_cls, entities, resolved):
     Handles two redirect patterns:
     - ``redirect_to`` on source (GND): source is old; latest points to current.
     - ``redirect_from`` on source (IDREF): source is current; older points to old record.
-    - Reverse lookup: search for records whose source ``redirect_to`` points at this
-      record's source PID, covering the GND case on the current/newer record.
+    - Falls back to :func:`_reverse_relation_urls` when the pointer isn't on this
+      record's own source sub-document.
     """
     latest_url = None
     older_url = None
@@ -308,33 +359,17 @@ def _compute_nav_urls(entity_type, record_cls, entities, resolved):
         src_data = resolved.get(src)
         if not isinstance(src_data, dict):
             continue
-        if rel := src_data.get("relation_pid"):
-            rel_type, rel_value = rel.get("type"), rel.get("value")
-            if rel_value and rel_type in ("redirect_to", "redirect_from"):
-                if record_cls.get_mef(rel_value, src, pid_only=True):
-                    if rel_type == "redirect_to":
-                        latest_url = url_for(
-                            _LATEST_ENDPOINT[entity_type], pid_type=src, pid=rel_value
-                        )
-                    else:
-                        older_url = url_for(
-                            _OLDER_ENDPOINT[entity_type], pid_type=src, pid=rel_value
-                        )
-        if not older_url and (src_pid := src_data.get("pid")):
-            for hit in (
-                record_cls.search()
-                .filter("term", **{f"{src}__relation_pid__value": src_pid})
-                .scan()
-            ):
-                hit_src = hit.to_dict().get(src, {})
-                if hit_src.get("relation_pid", {}).get("type") == "redirect_to":
-                    if older_src_pid := hit_src.get("pid"):
-                        older_url = url_for(
-                            _OLDER_ENDPOINT[entity_type],
-                            pid_type=src,
-                            pid=older_src_pid,
-                        )
-                        break
+        found_older, found_latest = _own_relation_url(
+            record_cls, entity_type, src, src_data.get("relation_pid")
+        )
+        older_url = older_url or found_older
+        latest_url = latest_url or found_latest
+        if (not older_url or not latest_url) and (src_pid := src_data.get("pid")):
+            found_older, found_latest = _reverse_relation_urls(
+                record_cls, entity_type, src, src_pid
+            )
+            older_url = older_url or found_older
+            latest_url = latest_url or found_latest
         if latest_url and older_url:
             break
     return latest_url, older_url

--- a/tests/api/test_agents_mef_rest.py
+++ b/tests/api/test_agents_mef_rest.py
@@ -138,6 +138,33 @@ def test_agents_mef_get_idref_latest(
     assert data == mef_data
 
 
+def test_agents_mef_find_redirect_target_via_idref(
+    agent_mef_record,
+    agent_idref_record,
+    agent_gnd_record,
+    agent_rero_record,
+    agent_idref_redirect_record,
+    agent_mef_idref_redirect_record,
+):
+    """_find_redirect_target follows an IDREF redirect even when reached via GND.
+
+    The GND source itself was never redirected: the redirect only exists on
+    the IDREF source. Builds the old record's resolved shape by hand so the
+    check is deterministic -- old and new share the same GND/RERO pids, so a
+    real get_latest() lookup by GND could match either one first in
+    Elasticsearch, which would make an end-to-end assertion order-dependent.
+    """
+    data = {
+        "gnd": {"pid": agent_gnd_record.pid},
+        "idref": {"pid": agent_idref_record.pid},
+        "rero": {"pid": agent_rero_record.pid},
+    }
+    assert AgentMefRecord._find_redirect_target(data) == (
+        "idref",
+        agent_idref_redirect_record.pid,
+    )
+
+
 def test_agents_mef_get_updated(
     client,
     agent_mef_record,

--- a/tests/ui/test_theme_views.py
+++ b/tests/ui/test_theme_views.py
@@ -92,6 +92,15 @@ def test_agent_detail_older_button_gnd_reverse(
     assert "mef-older-link" in res.get_data(as_text=True)
 
 
+def test_agent_detail_latest_button_idref_reverse(
+    client, agent_mef_idref_redirect_record, agent_mef_record
+):
+    """Old IDREF record shows Latest button via reverse redirect_from lookup."""
+    res = client.get(f"/agents/{agent_mef_record.pid}")
+    assert res.status_code == 200
+    assert "mef-latest-link" in res.get_data(as_text=True)
+
+
 def test_agent_detail_crosstype_redirect(client, agent_mef_crosstype_redirect_record):
     """MEF record whose GND source (bf:Organisation) redirects to a bf:Person shows the type-conflict alert.
 

--- a/uv.lock
+++ b/uv.lock
@@ -157,16 +157,16 @@ wheels = [
 
 [[package]]
 name = "build"
-version = "1.5.0"
+version = "1.5.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "os_name == 'nt'" },
     { name = "packaging" },
     { name = "pyproject-hooks" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/78/e0/df5e171f685f82f37b12e1f208064e24244911079d7b767447d1af7e0d70/build-1.5.0.tar.gz", hash = "sha256:302c22c3ba2a0fd5f3911918651341ebb3896176cbdec15bd421f80b1afc7647", size = 89796, upload-time = "2026-04-30T03:18:25.17Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/21/6ec54248b4d0d51f12f3ca4aa77a128077d747a5db86cb5a2fcd9aedecbd/build-1.5.1.tar.gz", hash = "sha256:94e17f1db803ab22f46049376c44c8437c52090f0dfdf1adc43df56542d644fb", size = 112439, upload-time = "2026-07-09T06:21:59.632Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl", hash = "sha256:13f3eecb844759ab66efec90ca17639bbf14dc06cb2fdf37a9010322d9c50a6f", size = 26018, upload-time = "2026-04-30T03:18:23.644Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/f7/2c3f99ff9282f1c1ec9f6298f2c03034658a0901eeacb3b3501cb488574c/build-1.5.1-py3-none-any.whl", hash = "sha256:f1a58fe2e5af5b0238a07b9e70207492c79ddebbdb1ad954fc86d62a56be3e0d", size = 31195, upload-time = "2026-07-09T06:21:58.551Z" },
 ]
 
 [[package]]
@@ -262,37 +262,37 @@ wheels = [
 
 [[package]]
 name = "charset-normalizer"
-version = "3.4.8"
+version = "3.4.9"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/20/56/10a88e00039537d74bd420f0457c52ab8f58a1af56126e3b9f1b1c8c4724/charset_normalizer-3.4.8.tar.gz", hash = "sha256:d9bf144d6faf12c70d58e47f7512992ae2882b820031d6cef68152deb645bf2d", size = 151790, upload-time = "2026-07-06T15:27:58.477Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/2a/23f34ec9d04624958e137efdc394888716353190e75f25dd22c7a2c7a8aa/charset_normalizer-3.4.9.tar.gz", hash = "sha256:673611bbd43f0810bec0b0f028ddeaaa501190339cac411f347ac76917c3ae7b", size = 152439, upload-time = "2026-07-07T14:34:58.454Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1c/bc/0a8540b8cd494951cca1428606373942803f5ffcec40fe798f819c5a8adb/charset_normalizer-3.4.8-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:77e993ecf65f21ab1f82266ff5e84a7de2c879e7d9b8bc006009df83f22a1d5e", size = 316993, upload-time = "2026-07-06T15:26:49.962Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/99/a0868f0a1f0a045fd374d1f2cf7042d8ad5d7fb4dd1f4ac7365e319f7e32/charset_normalizer-3.4.8-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:524939917f17f6de502dfda30b472550965740d7f126659d4c4f8dd1569cce22", size = 215638, upload-time = "2026-07-06T15:26:51.338Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/e9/43c4d09a09b5557cc5fe1d87c9d96f86a3942aec0517d2b5408cef87ca75/charset_normalizer-3.4.8-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a4508989ba8e2ce43ef989453d18188b261546e8188cbdd4ef451fb9e4c3b467", size = 236456, upload-time = "2026-07-06T15:26:52.531Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/67/492ca98b3ab785b736b5da10c1bc233e1c8fec6c0cdb29b482c38bfc52a2/charset_normalizer-3.4.8-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:9e44127f7d11eee4548ad2cdf1f4e1b6eaaddd5cb92d15ad65f6ecc9bcf403ab", size = 232253, upload-time = "2026-07-06T15:26:53.838Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/fd/1e6eff58c14f1aace1e26d80defbeaea2d35e075dbe4b611111ee4b47fa8/charset_normalizer-3.4.8-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bb90317359f7e67bb6df615999a95e0980877468e617ddce8b6c2f8e7fe60d95", size = 222886, upload-time = "2026-07-06T15:26:55.009Z" },
-    { url = "https://files.pythonhosted.org/packages/40/7a/90056a5326b0c4b9a3f924d337729c344c11542e5bc7191e50410db61587/charset_normalizer-3.4.8-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:35d9e7a9c960520ae89d1f4e305d1c047a74dea2e0f73a0e84f879356c2e8776", size = 206482, upload-time = "2026-07-06T15:26:56.306Z" },
-    { url = "https://files.pythonhosted.org/packages/18/ff/94761d31a33878dbb5008ddbd918615061fcf5c0a612aa3075450e60f628/charset_normalizer-3.4.8-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:92e322b054c7ff886f78feab7360736bb45de2e18cf4a0ee84e8fc5a08d53a19", size = 218929, upload-time = "2026-07-06T15:26:57.422Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/dc/00b9675acd7c4b926b9102ee3f0d1a570ce943901be73b87485001393fe1/charset_normalizer-3.4.8-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:3c0086d97094363556206dc3bcf43f7edcfc043ea7a568a46f45efea74858bd1", size = 218069, upload-time = "2026-07-06T15:26:58.719Z" },
-    { url = "https://files.pythonhosted.org/packages/04/11/94ada5a0482ee4bf688d04be4c7d6fd945d37370d04a95671040dfe2b416/charset_normalizer-3.4.8-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:0752c849b51198267df2aba013c4de3a2955bd014a4fd70828809946c1acbc0c", size = 207146, upload-time = "2026-07-06T15:27:00.058Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/f7/246bd36762207ab4752cd436b64e5d81a1668b15ddea7b5b2d0e8545e727/charset_normalizer-3.4.8-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2a4707e09eca11e81ece4fced600c5a0a801f568b962244f6f517bc274745fc9", size = 224896, upload-time = "2026-07-06T15:27:01.599Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/f7/3510622d1fbe13b0ebf827c475e40a27e2be427140d792878b63ab6425cc/charset_normalizer-3.4.8-cp314-cp314-win32.whl", hash = "sha256:8ea67f427c073ae3da0923aa55f3715131fa613a61a7f2f8d762bde75eaf00ae", size = 150851, upload-time = "2026-07-06T15:27:02.964Z" },
-    { url = "https://files.pythonhosted.org/packages/32/2b/9ce65dd21672b55cf800cca5f4433afa1586fda1d78731067ec9ec544c62/charset_normalizer-3.4.8-cp314-cp314-win_amd64.whl", hash = "sha256:ff71018850863362e5c7533769d0a9f77715c31af1502d523630ce822922f5c9", size = 162549, upload-time = "2026-07-06T15:27:04.249Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/34/9a5967eed666a88f31a0866884606d9ec3c2cd6091e2ccd7e0b4c4176c35/charset_normalizer-3.4.8-cp314-cp314-win_arm64.whl", hash = "sha256:44464e66f4da2f21dea7145c7693f9f60717ca4794a954dea5bf8c2c932678bd", size = 153079, upload-time = "2026-07-06T15:27:05.608Z" },
-    { url = "https://files.pythonhosted.org/packages/02/4f/aa44cc81d8987f105352c74c0bf919007f8b80e9880d28bcf0393c1a816e/charset_normalizer-3.4.8-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:50a0c2e58ad2c203adb616fef28941b7e13716adbc25e0dfaeec29f5afe6382f", size = 338586, upload-time = "2026-07-06T15:27:06.86Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/2b/b0392e2b235c08ff0623d905c2ee8ac820620544043c1ce92ce0b3d64c55/charset_normalizer-3.4.8-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8a1e589fdb95c76f08288bbb346230cdd8994db74903db6637b380f7b5fc9336", size = 222764, upload-time = "2026-07-06T15:27:08.23Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/a1/7d466879190731f5559662c22232646f2ae2dace2323c3e5aefcf78d458a/charset_normalizer-3.4.8-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b3d7c887444c5a7ef0d68d358d81e758a850bc626f8e639e2ca5667153272b20", size = 241331, upload-time = "2026-07-06T15:27:09.512Z" },
-    { url = "https://files.pythonhosted.org/packages/70/17/8b89e797137aa28c8fb0bafbafc243246a7afe21620a13b00e37624ece1d/charset_normalizer-3.4.8-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:65c389b96c0cfff3a3f0458fa1c7ce554a30e23101a88a49f03997afce6a929f", size = 239323, upload-time = "2026-07-06T15:27:10.86Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/98/1c1940730ed22d50983be4e243c722c89d5136d6f073bd840d1128bfddcb/charset_normalizer-3.4.8-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:593403fc47dcdf55e2987b2e3cc2e064127e2b908929f1f18b2e4a4652cbd780", size = 229964, upload-time = "2026-07-06T15:27:12.113Z" },
-    { url = "https://files.pythonhosted.org/packages/53/2d/bb8e81b7ff603d3f77e9a8a5d1ad34fcabbf3c54d300c29d99fba581fa23/charset_normalizer-3.4.8-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:606088e9fa2b7469ab9c42d4da8e05a415622a07714edd2fcd8fed48dda4c853", size = 212405, upload-time = "2026-07-06T15:27:13.447Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/1f/e52a3a53b13da591bb8f21d29e63877268eadf20686b7762351d4b89062c/charset_normalizer-3.4.8-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0317406326fed512f42a1632ad91a96228a7616c06547666a6dd79967f1bd6ca", size = 226918, upload-time = "2026-07-06T15:27:14.89Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/f9/32996d79c57189af9722fe618f46d8a86b7be035ca98887b8d0c3821f141/charset_normalizer-3.4.8-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:b67d50ee47e5c57a0064a9cb575b963a7125819dfd1fd094d44d378fff94659b", size = 225113, upload-time = "2026-07-06T15:27:16.125Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/d2/9248c18e695696513774523a794cfb8b677521ce9ad7554d301cb10a9b20/charset_normalizer-3.4.8-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:79e402b869f270140afa5e2b0e2ac100585358d812fe3dd093d424f7a72964e0", size = 214966, upload-time = "2026-07-06T15:27:17.418Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/9d/4b19432d406179a40f924691906ee5b15ac664b408971c973295192444ea/charset_normalizer-3.4.8-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2970b9f7ab69ec3a0423ec6b6ac718e79fbf4a282c0bc103ef88c1ef50dfa15a", size = 231699, upload-time = "2026-07-06T15:27:19.131Z" },
-    { url = "https://files.pythonhosted.org/packages/be/41/bdbdf71e8c3ccff10ef3cc2bb9467a7fdb3dc94b9a406d1a3c44afd39632/charset_normalizer-3.4.8-cp314-cp314t-win32.whl", hash = "sha256:458c2972a78043b7261c9726670029f15f722e70669bcbe961153a01968f589f", size = 155333, upload-time = "2026-07-06T15:27:20.681Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/f8/e05c69323bd50091ec39f5f885385b884624b0131a6885a0c83a6217ba7a/charset_normalizer-3.4.8-cp314-cp314t-win_amd64.whl", hash = "sha256:0c926329a1df7cd56d7d8349fe354460d20aefd2e394c9e159e479d018b2b359", size = 167378, upload-time = "2026-07-06T15:27:22.042Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/04/cbaf1a2f5e2bbf70760e774380cbf052b10849fc35e770905df31af5cf00/charset_normalizer-3.4.8-cp314-cp314t-win_arm64.whl", hash = "sha256:2232baea80a2b01783679fed4e625ccdb19a974f44c9cf0fba21a777a4c8179c", size = 157782, upload-time = "2026-07-06T15:27:23.312Z" },
-    { url = "https://files.pythonhosted.org/packages/23/52/d5bee5b6ea81882d549b566d2545b044bbcbc33fe5fbe001008a7e745a21/charset_normalizer-3.4.8-py3-none-any.whl", hash = "sha256:b7c1fb310df524e01fbe84d43b7f95aa4f808f8eaa0dafc185f64ba395e37d54", size = 64279, upload-time = "2026-07-06T15:27:57.043Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/8d/496817fa0944239ecae662dd57ea765cfeaec6a735f9f025d4b7b72e7143/charset_normalizer-3.4.9-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:0327fcd59a935777d83410750c50600ee9571af2846f71ce40f25b13da1ef380", size = 317253, upload-time = "2026-07-07T14:33:54.994Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/f9/ef4a69ea338ad3c0deceea0f5f7d2380ae8b52132b06d652cb0d2cd86706/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8a79d9f4d8001473a30c163556b3c3bfebec837495a412dde78b51672f6134f9", size = 215898, upload-time = "2026-07-07T14:33:56.334Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/e7/5ddfd76fc061eb52de219658a4aa431cbacadf0a0219c8854f00da50d289/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:33bdcc2a32c0a0e861f60841a512c8acc658c87c2ac59d89e3a46dacf7d866e4", size = 236718, upload-time = "2026-07-07T14:33:57.9Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ba/768fa3f36048d81c477a0ce61f813bc1454d80917ccfe550abd9f44f5e24/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f840ed6d8ecba8255df8c42b87fadeda98ddfc6eeec05e2dc66e26d46dd6f58a", size = 232519, upload-time = "2026-07-07T14:33:59.811Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/c4/b3e049d2aa3766180c78507110543d9d50894cc97f57de543f1be521dcdc/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c25fe15c70c59eb7c5ce8c06a1f3fa1da0ecc5ea1e7a5922c40fd2fa9b0d5046", size = 223143, upload-time = "2026-07-07T14:34:01.517Z" },
+    { url = "https://files.pythonhosted.org/packages/19/79/55c32d06d76ae4feafe053f061f3e3ab70bcf19f4007797ce8c3efda7830/charset_normalizer-3.4.9-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:f7fb7d750cfa0a070d2c24e831fd3481019a60dd317ea2b39acbcebc08b6ed81", size = 206742, upload-time = "2026-07-07T14:34:03.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/e0/47c079dd82d217c807479cd59ffd30af56307ea31c108b75758970459ad3/charset_normalizer-3.4.9-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4d1c96a7a18b9690a4d46df09e3e3382406ae3213727cd1019ebade1c4a81917", size = 219191, upload-time = "2026-07-07T14:34:04.657Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ab/b9bc2e77d6b44a7e46ef62ec5cac1c9a6ba7b9135a5d560f002696ec9995/charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a4cfde78a9f2880208d16a93b795726a3017d5977e08d1e162a7a31322479c41", size = 218328, upload-time = "2026-07-07T14:34:06.115Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/78/c9c71d599f5aa2d42bcdd35cbbd46d7f535351a57e40ff7d8e5a7e219401/charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:d4d6fcde76f94f5cb9e43e9e9a61f16dacefd228cbbf6f1a09bd9b219a92f1a1", size = 207406, upload-time = "2026-07-07T14:34:07.554Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/39/c914445c321a845097ce4f6ac7de9a18228a77b766272125a1ce00d851eb/charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:898f0e9068ca27d37f8e83a5b962821df851532e6c4a7d615c1c033f9da6eedf", size = 225157, upload-time = "2026-07-07T14:34:09.061Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/f2/c0d4b8508565a36bc5c624e88ed297f5b0b1095011034d7f5b83a69908b5/charset_normalizer-3.4.9-cp314-cp314-win32.whl", hash = "sha256:c1c948747b03be832dceed96ca815cef7360de9aa19d37c730f8e3f6101aca48", size = 151095, upload-time = "2026-07-07T14:34:10.901Z" },
+    { url = "https://files.pythonhosted.org/packages/49/fd/a1d26144398c67486422a72bf5812cda22cb4ccfcd95a290fb41ceb4b8e2/charset_normalizer-3.4.9-cp314-cp314-win_amd64.whl", hash = "sha256:16b65ea0f2465b6fb52aa22de5eca612aa964ddfec00a912e26f4656cbef890b", size = 162796, upload-time = "2026-07-07T14:34:12.47Z" },
+    { url = "https://files.pythonhosted.org/packages/20/95/d75e82f8ce9fd323ebf059c16c9aadefb22a1ecde13b7840b35835e4886c/charset_normalizer-3.4.9-cp314-cp314-win_arm64.whl", hash = "sha256:40a126142a56b2dfc0aacbad1de8310cbf60da7656db0e6b16eebd48e3e93519", size = 153334, upload-time = "2026-07-07T14:34:14.044Z" },
+    { url = "https://files.pythonhosted.org/packages/00/5e/17398df3a139985ba9d11ed072531986f408c8fca952835ef1ab1820c02b/charset_normalizer-3.4.9-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:609b3ba8fcc0fb5ab7af00719d0fb6ad0cb518e48e7712d12fd68f1327951198", size = 338848, upload-time = "2026-07-07T14:34:15.688Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/91/7253a32e86b7e1d1239b1b36ba6dd0f021a21107ab33054b53119cc083b9/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:51447e9aa2684679af07ca5021c3db526e0284347ebf4ffcec1154c3350cfe32", size = 223022, upload-time = "2026-07-07T14:34:17.248Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/32/2e64bd2be10e89c61e57ebe6a93fd98ae88eb7ebe414b5121f22c96c69eb/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cc1b0fff8ead343dae06305f954eb8468ba0ec1a97881f42489d198e4ce3c632", size = 241590, upload-time = "2026-07-07T14:34:18.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/ef/d96ec496cfea0c21db43b0ad03891308b02388d054cc902cf0e5a1ad6a88/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:fa36ec09ef71d158186bc79e359ff5fdd6e7996fe8ab638f00d6b93139ba4fcf", size = 239584, upload-time = "2026-07-07T14:34:20.52Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/ce/9af95f7876194bd7a14e3dfe4a4de2e0bff02666a3910d72beafd06cc297/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:df115d4d83168fdf2cae48ef1ff6d1cb4c466364e30861b37121de0f3bf1b990", size = 230224, upload-time = "2026-07-07T14:34:22.189Z" },
+    { url = "https://files.pythonhosted.org/packages/52/94/af74dde74a3996bd959c350709bfe50e297823d70a8c1cbd54b838880863/charset_normalizer-3.4.9-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:f86c6358749bd4fda175388691e3ba8c46e24c5347d0afd20f9b7edfc9faf07d", size = 212667, upload-time = "2026-07-07T14:34:23.857Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/f0/f1c4fe746c395922961b5916ed1d7d6e7d4c84851d19ed43cc89980ec953/charset_normalizer-3.4.9-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:32286a2c8d167e897177b673176c1e3e00d4057caf5d2b64eef9a3666b03018e", size = 227179, upload-time = "2026-07-07T14:34:25.586Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/56/6c745619ac397e8871e2bcd3cea1eec86b877488f33888b3aef5c3ed506e/charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:83aed2c10721ddd90f68140685391b50811a880af20654c59af6b6c66c40513c", size = 225372, upload-time = "2026-07-07T14:34:27.212Z" },
+    { url = "https://files.pythonhosted.org/packages/78/ad/98aae8630ac71f16711968e38a5acfecce41b778bf2f0312851020f565a8/charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cd6c3d4b783c556fa00bf540854e42f135e2f256abd29669fcd0da0f2dec79c2", size = 215222, upload-time = "2026-07-07T14:34:28.774Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/40/9593d54209765207a7f11073c06494c1721e4ca4a0a426c597679bf7f91e/charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ee2f2a527e3c1a6e6411eb4209642e138b544a2d72fe5d0d76daf77b24063534", size = 231958, upload-time = "2026-07-07T14:34:30.345Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/27/693ee5e8a18191eb38647360c51cd505013e2bd3b366aa43fd5344c21e3c/charset_normalizer-3.4.9-cp314-cp314t-win32.whl", hash = "sha256:0d861473f743244d349b50f850d10eb87aeb22bbdcc8e64f79273c94af5a8226", size = 155580, upload-time = "2026-07-07T14:34:31.884Z" },
+    { url = "https://files.pythonhosted.org/packages/80/3f/bd97d3d9c613013d07cb7733d299385b41df37f0471310f5a73dc359f0b8/charset_normalizer-3.4.9-cp314-cp314t-win_amd64.whl", hash = "sha256:9b8e0f3107e2200b76f6054de99016eac3ee6762713587b36baaa7e4bd2ae177", size = 167620, upload-time = "2026-07-07T14:34:33.438Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/c6/eee9dca4439b1061f76373f06ea855678cc4a64c1c3c90b50e479edbb8eb/charset_normalizer-3.4.9-cp314-cp314t-win_arm64.whl", hash = "sha256:19ac87f93086ce37b86e098888555c4b4bc48102279bae3350098c0ed664b501", size = 158037, upload-time = "2026-07-07T14:34:35.018Z" },
+    { url = "https://files.pythonhosted.org/packages/98/2b/f97f1c193fb855c345d678f5077d6926034db0722df74c8f057020e05a25/charset_normalizer-3.4.9-py3-none-any.whl", hash = "sha256:68e5f26a1ad57ded6d1cfb85331d1c1a195314756471d97758c48498bb4dcdf5", size = 64538, upload-time = "2026-07-07T14:34:56.993Z" },
 ]
 
 [[package]]
@@ -643,11 +643,11 @@ wheels = [
 
 [[package]]
 name = "filelock"
-version = "3.29.6"
+version = "3.29.7"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e0/c8/35bdf04fb30755e2ed758f877edf3eb4a243c2463d3a258cc28b18b7a6e2/filelock-3.29.6.tar.gz", hash = "sha256:895c532ef3f4ef04972b9446a8c4e2931a5c399ff3c4be4c9369f2639b80f793", size = 70301, upload-time = "2026-07-06T23:08:08.577Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/35/94/00f2059e4835eace3ae8fde680b932c496f8ec7bdc99168dfa53fb2e6b79/filelock-3.29.7.tar.gz", hash = "sha256:5b481979797ae69e72f0b389d89a80bdd585c260c5b3f1fb9c0a5ba9bb3f195d", size = 71521, upload-time = "2026-07-08T05:46:58.716Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bb/49/7467c2946ccd9617f7da38187071bdc45bb9a95df51f4d63d6622432ce4e/filelock-3.29.6-py3-none-any.whl", hash = "sha256:14d5f5597d2e0c4dbd774cfb6d8132da1db44da83732aab679d54f7dcf97ab65", size = 45478, upload-time = "2026-07-06T23:08:07.197Z" },
+    { url = "https://files.pythonhosted.org/packages/60/02/be4a57b60c7149b55b9e3b3c13f609cd8eb5307c751f22bd8fb8d262e75b/filelock-3.29.7-py3-none-any.whl", hash = "sha256:987db6f789a3a2a59f55081801b2b3697cb97e2a736b5f1a9e99b559285fbc51", size = 46036, upload-time = "2026-07-08T05:46:57.53Z" },
 ]
 
 [[package]]
@@ -698,15 +698,15 @@ wheels = [
 
 [[package]]
 name = "flask-caching"
-version = "2.4.0"
+version = "2.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cachelib" },
     { name = "flask" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/42/53/5c46b6a80adc13ed9179879a93cfc2c1f190c64c48ba732b4f5819df520e/flask_caching-2.4.0.tar.gz", hash = "sha256:a7f14e43617cd0612a57bec2f80516d6d2ec888bfc50a807b1e4e41ca345a3b5", size = 153673, upload-time = "2026-04-17T20:27:24.318Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/89/15/d2852e86419c6c1416cba00c177b2cf609b5c2935372933684f84111c631/flask_caching-2.4.1.tar.gz", hash = "sha256:ecef4ca80b9cb1fa01d461373a0fce441527cd57eecee1aa71c1f6d750d7ff77", size = 165380, upload-time = "2026-07-08T19:23:57.264Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/7c/acd8624c1295bcf10c0b67d0e5191b570081b181bc0e8aa5a5a8ab89ca0d/flask_caching-2.4.0-py3-none-any.whl", hash = "sha256:d15b8135f055c4f28f6f7dbcf8d36a3de4af1224def975ae6e0b43cbfa684486", size = 28727, upload-time = "2026-04-17T20:27:22.763Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/e3/ad7572c7f00b1286f2fc2a387f01b62bb46b59c5f91536093eae57889adb/flask_caching-2.4.1-py3-none-any.whl", hash = "sha256:5f5555d610ec1f230c8200ae00c1c723ee562f657c22f896b806f4689513b952", size = 28977, upload-time = "2026-07-08T19:23:55.68Z" },
 ]
 
 [[package]]
@@ -1448,7 +1448,7 @@ wheels = [
 
 [[package]]
 name = "invenio-records-rest"
-version = "6.0.0"
+version = "6.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "bleach" },
@@ -1461,9 +1461,9 @@ dependencies = [
     { name = "invenio-rest" },
     { name = "marshmallow-utils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/a8/38262cd24af44c7c1773c348f13014aba547ac4ab92711855c07088ea281/invenio_records_rest-6.0.0.tar.gz", hash = "sha256:e640b5a44ce57ef920f8a070e115c3e56f5c0eda48ad7c0990b746b2d88bd5e4", size = 68338, upload-time = "2026-06-17T21:51:16.726Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/b6/4ea29f720ce12eea8d4dc2cba236d55b684a0e02895778d2cffdb082c411/invenio_records_rest-6.0.1.tar.gz", hash = "sha256:e7549ed3b7cf942837c415d7455980bbaa057ddc8c9f7886b49773e511f1ba0a", size = 50382, upload-time = "2026-07-09T06:44:08.119Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/17/3b/01e1ad01fa53f8be59b2a36254b7f8ad01e99a63fe442ad1660c7a6aad68/invenio_records_rest-6.0.0-py2.py3-none-any.whl", hash = "sha256:36afe0217038629e0d5ee1b699ba7ed5f62ad6ded3d8a59f36152ed909b59ab3", size = 135469, upload-time = "2026-06-17T21:51:15.55Z" },
+    { url = "https://files.pythonhosted.org/packages/25/ee/ece58f3692a6853917d8f25125ea2e2f039c221b69d636134b5bdef7f1bc/invenio_records_rest-6.0.1-py3-none-any.whl", hash = "sha256:98740b2f84ad9108459e577911d0eeb77c4f9ef7776cf63f47fecacabacd1ff8", size = 103044, upload-time = "2026-07-09T06:44:06.92Z" },
 ]
 
 [[package]]
@@ -2745,7 +2745,7 @@ wheels = [
 
 [[package]]
 name = "rero-invenio-base"
-version = "1.1.1"
+version = "1.1.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "invenio-db", extra = ["postgresql"] },
@@ -2754,9 +2754,9 @@ dependencies = [
     { name = "jsonpatch" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6e/32/8ae82e4bdcf8ef0e27fbebd19ec6cfc0e9a0319070b2253f18b4762fcd23/rero_invenio_base-1.1.1.tar.gz", hash = "sha256:57e34ddc7e1a630765cd0cf581ab8c8903c26fc2b6a9881fd0ad59b548374a79", size = 29389, upload-time = "2026-07-06T14:46:27.354Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7c/1a/582c875a9f8f527b9b60138b7fa3d61325eb040fe3131e456db8bb54899a/rero_invenio_base-1.1.2.tar.gz", hash = "sha256:9529ef86d489c03b498566569d22f864cbe6f0c66e63d2ecc204bda0b92dda9f", size = 29404, upload-time = "2026-07-09T07:59:40.071Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bc/81/d9c3c9409d9e77848b3e50763ffc9d5314e5808a599a4c353d36a154bee8/rero_invenio_base-1.1.1-py3-none-any.whl", hash = "sha256:0e3e1a6327d153feaab79f148c9d68364e5ff9f74cd8c087ca70ec8ac738937d", size = 40484, upload-time = "2026-07-06T14:46:26.514Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/61/071e468d821dd92c143cde1ed6e27915dd07fbef5f6bcab64d26c3cfcb7c/rero_invenio_base-1.1.2-py3-none-any.whl", hash = "sha256:20f64ff008ac145211008e79217c2307aa9a017508d019334d52d832cb47a601", size = 40499, upload-time = "2026-07-09T07:59:39.112Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
* get_latest() only checked the redirect on the pid_type it was called with; add a shared _find_redirect_target() on EntityMefRecord that checks every linked source (idref, gnd, rero) instead, fixing lookups like /agents/mef/latest/gnd:X when only the idref source redirected
* de-duplicate three byte-for-byte identical (and buggy) get_latest implementations in agents/concepts/places mef api.py into that shared base class method
* theme/views.py: _compute_nav_urls had the same gap for the MEF detail page's Latest/Older buttons; add the missing reverse redirect_from lookup and extract _own_relation_url / _reverse_relation_urls for readability and testability
* add regression tests: a deterministic _find_redirect_target unit test (avoids relying on ambiguous Elasticsearch ordering) and a UI test for the previously-missing Latest button

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved MEF detail-page navigation so “latest” and “older” links can resolve across redirect relationships, including reverse lookups.
  * Detail pages now better handle redirects between record types, helping users reach the correct record more reliably.

* **Bug Fixes**
  * Fixed redirect handling for records reached through alternate identifier paths, reducing missing or incorrect navigation links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->