### PR TITLE
refactor(mef): dedupe get_latest/refs/indexer across MEF families

### DIFF
--- a/rero_mef/agents/mef/api.py
+++ b/rero_mef/agents/mef/api.py
@@ -3,13 +3,9 @@
 
 """API for manipulating MEF records."""
 
-from copy import deepcopy
-
-from flask import current_app
 from invenio_search.api import RecordsSearch
 
-from rero_mef.api import EntityIndexer
-from rero_mef.api_mef import EntityMefRecord
+from rero_mef.api_mef import EntityMefRecord, MefIndexer
 from rero_mef.utils import get_entity_classes
 
 from ..api import get_all_missing_viaf_pids
@@ -80,45 +76,6 @@ class AgentMefRecord(EntityMefRecord):
             **kwargs,
         )
 
-    def replace_refs(self):
-        """Replace $ref with real data."""
-        data = deepcopy(self)
-        data = super().replace_refs()
-        sources = [agent for agent in self.entities if data.get(agent)]
-        data["sources"] = sources
-        return data
-
-    def add_information(self, resolve=False, sources=False):
-        """Add information to record.
-
-        Sources will be also added if resolve is True.
-        :param resolve: resolve $refs
-        :param sources: Add sources information to record
-        :returns: record
-        """
-        replace_refs_data = AgentMefRecord(deepcopy(self).replace_refs())
-        data = replace_refs_data if resolve else deepcopy(self)
-        my_sources = []
-        for agent in self.entities:
-            if agent_data := data.get(agent):
-                # we got a error status in data
-                if agent_data.get("status"):
-                    data.pop(agent)
-                    current_app.logger.error(
-                        f"MEF replace refs {data.get('pid')} {agent}"
-                        f" status: {agent_data.get('status')}"
-                        f" {agent_data.get('message')}"
-                    )
-                else:
-                    my_sources.append(agent)
-                for agent in self.entities:
-                    if agent_data := replace_refs_data.get(agent):
-                        if metadata := replace_refs_data[agent].get("metadata"):
-                            data[agent] = metadata
-        if my_sources and (resolve or sources):
-            data["sources"] = my_sources
-        return data
-
     @classmethod
     def get_all_missing_viaf_pids(cls, verbose=False):
         """Get VIAF pids missing from MEF and MEF records with non-existing VIAF pids.
@@ -129,16 +86,7 @@ class AgentMefRecord(EntityMefRecord):
         return get_all_missing_viaf_pids(verbose=verbose)
 
 
-class AgentMefIndexer(EntityIndexer):
+class AgentMefIndexer(MefIndexer):
     """Agent MEF indexer."""
 
     record_cls = AgentMefRecord
-
-    def bulk_index(self, record_id_iterator):
-        """Bulk index records.
-
-        :param record_id_iterator: Iterator yielding record UUIDs.
-        """
-        super().bulk_index(
-            record_id_iterator, index=AgentMefSearch.Meta.index, doc_type="mef"
-        )

--- a/rero_mef/agents/mef/serializers.py
+++ b/rero_mef/agents/mef/serializers.py
@@ -12,6 +12,7 @@ from invenio_records_rest.serializers.response import (
     search_responsify,
 )
 
+from ...api_mef import _INDEX_ONLY_FIELDS
 from ...utils import get_entity_classes
 
 
@@ -40,6 +41,25 @@ def local_link(agent, name, record):
 
 class ReroMefSerializer(JSONSerializer):
     """Mixin serializing records as JSON."""
+
+    @staticmethod
+    def preprocess_search_hit(pid, record_hit, links_factory=None, **kwargs):
+        """Strip index-only bookkeeping fields from a search hit's metadata.
+
+        ``record_hit["_source"]`` is the raw ES-indexed document, which
+        carries fields injected at index time (entity, pid_numeric,
+        sort_authorized_access_point, type_conflict) or by MD5Extension
+        (md5) that a strict ``additionalProperties: false`` consumer schema
+        (e.g. rero-ils's) rejects. Unlike the single-item ``serialize()``
+        path, which resolves through ``add_information()``, search results
+        go through this method instead and never touch that stripping.
+        """
+        record = JSONSerializer.preprocess_search_hit(
+            pid, record_hit, links_factory=links_factory, **kwargs
+        )
+        for field in _INDEX_ONLY_FIELDS:
+            record["metadata"].pop(field, None)
+        return record
 
     def serialize(self, pid, record, links_factory=None, **kwargs):
         """Serialize a single record and persistent identifier.

--- a/rero_mef/api_mef.py
+++ b/rero_mef/api_mef.py
@@ -3,14 +3,24 @@
 
 """API for manipulating MEF records."""
 
+from copy import deepcopy
 from datetime import UTC, datetime
 
 from dateutil import parser
 from elasticsearch_dsl import Q
 from flask import current_app
 
-from .api import Action, EntityRecord
+from .api import Action, EntityIndexer, EntityRecord
 from .utils import generate, get_entity_class, get_entity_search_class, progressbar
+
+# Fields injected by before_record_index signal handlers (entity,
+# sort_authorized_access_point, pid_numeric, type_conflict) or by
+# MD5Extension (md5) that are internal bookkeeping and were never meant to
+# be part of a MEF record's public representation -- consumers validating
+# against a strict additionalProperties: false schema reject them.
+_INDEX_ONLY_FIELDS = frozenset(
+    {"entity", "md5", "pid_numeric", "sort_authorized_access_point", "type_conflict"}
+)
 
 
 class EntityMefRecord(EntityRecord):
@@ -212,53 +222,14 @@ class EntityMefRecord(EntityRecord):
         if not data.get("resolve"):
             search = search.source(["pid", "deleted", "_created", "_updated"])
         deleted = cls.get_deleted(missing_pids, from_date)
-        return generate(search, deleted)
-
-    @classmethod
-    def _find_redirect_target(cls, data):
-        """Find a newer (pid_type, pid) that the MEF record *data* redirects to.
-
-        Checks every source linked to *data*, not just one -- a MEF record can
-        be superseded via a different source than the one it was looked up by
-        (e.g. its IDREF source moved on while its GND source stayed put).
-        Handles both redirect conventions:
-
-        - ``redirect_to`` on the source itself (GND: the pointer is on the old
-          record).
-        - ``redirect_from`` on another record pointing back at this one
-          (IDREF: the pointer is on the new record, found via reverse lookup).
-
-        :param data: A MEF record dict with resolved source sub-documents.
-        :returns: (pid_type, pid) tuple, or None if no redirect target is found.
-        """
-        for source in cls.entities:
-            source_data = data.get(source)
-            if not isinstance(source_data, dict):
-                continue
-            if relation_pid := source_data.get("relation_pid"):
-                if relation_pid.get("type") == "redirect_to" and (
-                    value := relation_pid.get("value")
-                ):
-                    return source, value
-            if source_pid := source_data.get("pid"):
-                reverse = cls.search().filter(
-                    "term", **{f"{source}__relation_pid__value": source_pid}
-                )
-                for hit in reverse.scan():
-                    reverse_data = hit.to_dict()
-                    reverse_rel = reverse_data.get(source, {}).get("relation_pid", {})
-                    if reverse_rel.get("type") == "redirect_from" and (
-                        new_pid := reverse_data.get(source, {}).get("pid")
-                    ):
-                        return source, new_pid
-        return None
+        return generate(search, deleted, exclude_fields=_INDEX_ONLY_FIELDS)
 
     @classmethod
     def get_latest(cls, pid_type, pid, _visited=None):
         """Get latest Mef record for pid_type and pid.
 
-        :param pid_type: pid type to use for the initial lookup.
-        :param pid: pid to use for the initial lookup.
+        :param pid_type: pid type to use.
+        :param pid: pid to use.
         :param _visited: set of already-seen (pid_type, pid) pairs used to
             break redirect cycles.
         :returns: latest record.
@@ -272,9 +243,34 @@ class EntityMefRecord(EntityRecord):
         if search.count() == 0:
             return {}
         data = next(search.scan()).to_dict()
-        if target := cls._find_redirect_target(data):
-            new_pid_type, new_pid = target
-            return cls.get_latest(pid_type=new_pid_type, pid=new_pid, _visited=visited)
+        new_pid = None
+        if (
+            relation_pid := data.get(pid_type, {}).get("relation_pid")
+        ) and relation_pid["type"] == "redirect_to":
+            new_pid = relation_pid["value"]
+        if not new_pid and pid_type == "idref":
+            # Find a newer record whose relation_pid redirects_from this one
+            # (the IDREF convention: the pointer lives on the new record,
+            # not on this one). Runs regardless of whether this record has
+            # its own redirect_from pointer (documenting where it came
+            # from), since that says nothing about whether it was in turn
+            # superseded. Iterate every match rather than just the first: a
+            # record can be both redirected_to (by an older one) and
+            # redirected_from (by a newer one) at once, so the first hit
+            # isn't necessarily the one with the redirect_from pointer.
+            reverse = cls.search().filter("term", idref__relation_pid__value=pid)
+            for hit in reverse.scan():
+                hit_data = hit.to_dict()
+                hit_rel = hit_data.get("idref", {}).get("relation_pid", {})
+                if hit_rel.get("type") == "redirect_from" and (
+                    candidate := hit_data.get("idref", {}).get("pid")
+                ):
+                    new_pid = candidate
+                    break
+        if new_pid:
+            return cls.get_latest(pid_type=pid_type, pid=new_pid, _visited=visited)
+        for field in _INDEX_ONLY_FIELDS:
+            data.pop(field, None)
         return data
 
     def delete_ref(self, record, dbcommit=False, reindex=False):
@@ -327,3 +323,66 @@ class EntityMefRecord(EntityRecord):
             if entity_record := record_class.get_record_by_pid(entity["pid"]):
                 entities_records.append(entity_record)
         return entities_records
+
+    def replace_refs(self):
+        """Replace $ref with real data."""
+        data = super().replace_refs()
+        data["sources"] = [
+            entity
+            for entity in self.entities
+            if (entity_data := data.get(entity)) and not entity_data.get("status")
+        ]
+        return data
+
+    def add_information(self, resolve=False, sources=False):
+        """Add information to record.
+
+        Sources will be also added if resolve is True.
+        :param resolve: resolve $refs
+        :param sources: Add sources information to record
+        :returns: record
+        """
+        replace_refs_data = type(self)(deepcopy(self).replace_refs())
+        data = replace_refs_data if resolve else deepcopy(self)
+        my_sources = []
+        for entity in self.entities:
+            if entity_data := data.get(entity):
+                # we got a error status in data
+                if entity_data.get("status"):
+                    data.pop(entity)
+                    current_app.logger.error(
+                        f"MEF replace refs {data.get('pid')} {entity}"
+                        f" status: {entity_data.get('status')}"
+                        f" {entity_data.get('message')}"
+                    )
+                else:
+                    my_sources.append(entity)
+        for entity in self.entities:
+            if metadata := replace_refs_data.get(entity, {}).get("metadata"):
+                data[entity] = metadata
+        if my_sources and (resolve or sources):
+            data["sources"] = my_sources
+        for field in _INDEX_ONLY_FIELDS:
+            data.pop(field, None)
+        return data
+
+
+class MefIndexer(EntityIndexer):
+    """Shared indexer for MEF aggregation records (agents/concepts/places).
+
+    Defaults ``index``/``doc_type`` from the indexer's ``record_cls``, so
+    subclasses only need to set that one class attribute.
+    """
+
+    def bulk_index(self, record_id_iterator, index=None, doc_type=None):
+        """Bulk index records.
+
+        :param record_id_iterator: Iterator yielding record UUIDs.
+        :param index: Index name (optional).
+        :param doc_type: Document type (optional).
+        """
+        super().bulk_index(
+            record_id_iterator,
+            index=index or self.record_cls.search.Meta.index,
+            doc_type=doc_type or self.record_cls.provider.pid_type,
+        )

--- a/rero_mef/concepts/mef/api.py
+++ b/rero_mef/concepts/mef/api.py
@@ -3,13 +3,9 @@
 
 """API for manipulating MEF records."""
 
-from copy import deepcopy
-
-from flask import current_app
 from invenio_search.api import RecordsSearch
 
-from rero_mef.api import EntityIndexer
-from rero_mef.api_mef import EntityMefRecord
+from rero_mef.api_mef import EntityMefRecord, MefIndexer
 
 from ..utils import get_concept_classes
 from .fetchers import mef_id_fetcher
@@ -102,58 +98,8 @@ class ConceptMefRecord(EntityMefRecord):
             **kwargs,
         )
 
-    def replace_refs(self):
-        """Replace $ref with real data."""
-        data = deepcopy(self)
-        data = super().replace_refs()
-        data["sources"] = [concept for concept in self.entities if data.get(concept)]
-        return data
 
-    def add_information(self, resolve=False, sources=False):
-        """Add information to record.
-
-        Sources will be also added if resolve is True.
-        :param resolve: resolve $refs
-        :param sources: Add sources information to record
-        :returns: record
-        """
-        replace_refs_data = ConceptMefRecord(deepcopy(self).replace_refs())
-        data = replace_refs_data if resolve else deepcopy(self)
-        my_sources = []
-        for concept in self.entities:
-            if concept_data := data.get(concept):
-                # we got a error status in data
-                if concept_data.get("status"):
-                    data.pop(concept)
-                    current_app.logger.error(
-                        f"MEF replace refs {data.get('pid')} {concept}"
-                        f" status: {concept_data.get('status')}"
-                        f" {concept_data.get('message')}"
-                    )
-                else:
-                    my_sources.append(concept)
-                for concept in self.entities:
-                    if metadata := replace_refs_data.get(concept, {}).get("metadata"):
-                        data[concept] = metadata
-        if my_sources and (resolve or sources):
-            data["sources"] = my_sources
-        return data
-
-
-class ConceptMefIndexer(EntityIndexer):
+class ConceptMefIndexer(MefIndexer):
     """Concept MEF indexer."""
 
     record_cls = ConceptMefRecord
-
-    def bulk_index(self, record_id_iterator, index=None, doc_type=None):
-        """Bulk index records.
-
-        :param record_id_iterator: Iterator yielding record UUIDs.
-        :param index: Index name (optional).
-        :param doc_type: Document type (optional).
-        """
-        super().bulk_index(
-            record_id_iterator,
-            index=index or ConceptMefSearch.Meta.index,
-            doc_type=doc_type or "comef",
-        )

--- a/rero_mef/concepts/mef/serializers.py
+++ b/rero_mef/concepts/mef/serializers.py
@@ -12,6 +12,7 @@ from invenio_records_rest.serializers.response import (
     search_responsify,
 )
 
+from ...api_mef import _INDEX_ONLY_FIELDS
 from ...utils import get_entity_classes
 
 
@@ -42,6 +43,25 @@ def local_link(concept, name, record):
 
 class ReroMefSerializer(JSONSerializer):
     """Mixin serializing records as JSON."""
+
+    @staticmethod
+    def preprocess_search_hit(pid, record_hit, links_factory=None, **kwargs):
+        """Strip index-only bookkeeping fields from a search hit's metadata.
+
+        ``record_hit["_source"]`` is the raw ES-indexed document, which
+        carries fields injected at index time (entity, pid_numeric,
+        sort_authorized_access_point, type_conflict) or by MD5Extension
+        (md5) that a strict ``additionalProperties: false`` consumer schema
+        (e.g. rero-ils's) rejects. Unlike the single-item ``serialize()``
+        path, which resolves through ``add_information()``, search results
+        go through this method instead and never touch that stripping.
+        """
+        record = JSONSerializer.preprocess_search_hit(
+            pid, record_hit, links_factory=links_factory, **kwargs
+        )
+        for field in _INDEX_ONLY_FIELDS:
+            record["metadata"].pop(field, None)
+        return record
 
     def serialize(self, pid, record, links_factory=None, **kwargs):
         """Serialize a single record and persistent identifier.

--- a/rero_mef/places/mef/api.py
+++ b/rero_mef/places/mef/api.py
@@ -3,13 +3,9 @@
 
 """API for manipulating MEF records."""
 
-from copy import deepcopy
-
-from flask import current_app
 from invenio_search.api import RecordsSearch
 
-from rero_mef.api import EntityIndexer
-from rero_mef.api_mef import EntityMefRecord
+from rero_mef.api_mef import EntityMefRecord, MefIndexer
 
 from .fetchers import mef_id_fetcher
 from .minters import mef_id_minter
@@ -80,54 +76,8 @@ class PlaceMefRecord(EntityMefRecord):
             **kwargs,
         )
 
-    def replace_refs(self):
-        """Replace $ref with real data."""
-        data = deepcopy(self)
-        data = super().replace_refs()
-        data["sources"] = [place for place in self.entities if data.get(place)]
-        return data
 
-    def add_information(self, resolve=False, sources=False):
-        """Add information to record.
-
-        Sources will be also added if resolve is True.
-        :param resolve: resolve $refs
-        :param sources: Add sources information to record
-        :returns: record
-        """
-        replace_refs_data = PlaceMefRecord(deepcopy(self).replace_refs())
-        data = replace_refs_data if resolve else deepcopy(self)
-        my_sources = []
-        for place in self.entities:
-            if place_data := data.get(place):
-                # we got a error status in data
-                if place_data.get("status"):
-                    data.pop(place)
-                    current_app.logger.error(
-                        f"MEF replace refs {data.get('pid')} {place}"
-                        f" status: {place_data.get('status')}"
-                        f" {place_data.get('message')}"
-                    )
-                else:
-                    my_sources.append(place)
-                for place in self.entities:
-                    if metadata := replace_refs_data.get(place, {}).get("metadata"):
-                        data[place] = metadata
-        if my_sources and (resolve or sources):
-            data["sources"] = my_sources
-        return data
-
-
-class PlaceMefIndexer(EntityIndexer):
+class PlaceMefIndexer(MefIndexer):
     """Place MEF indexer."""
 
     record_cls = PlaceMefRecord
-
-    def bulk_index(self, record_id_iterator):
-        """Bulk index records.
-
-        :param record_id_iterator: Iterator yielding record UUIDs.
-        """
-        super().bulk_index(
-            record_id_iterator, index=PlaceMefSearch.Meta.index, doc_type="plmef"
-        )

--- a/rero_mef/places/mef/serializers.py
+++ b/rero_mef/places/mef/serializers.py
@@ -12,6 +12,7 @@ from invenio_records_rest.serializers.response import (
     search_responsify,
 )
 
+from ...api_mef import _INDEX_ONLY_FIELDS
 from ...utils import get_entity_classes
 
 
@@ -42,6 +43,25 @@ def local_link(place, name, record):
 
 class ReroMefSerializer(JSONSerializer):
     """Mixin serializing records as JSON."""
+
+    @staticmethod
+    def preprocess_search_hit(pid, record_hit, links_factory=None, **kwargs):
+        """Strip index-only bookkeeping fields from a search hit's metadata.
+
+        ``record_hit["_source"]`` is the raw ES-indexed document, which
+        carries fields injected at index time (entity, pid_numeric,
+        sort_authorized_access_point, type_conflict) or by MD5Extension
+        (md5) that a strict ``additionalProperties: false`` consumer schema
+        (e.g. rero-ils's) rejects. Unlike the single-item ``serialize()``
+        path, which resolves through ``add_information()``, search results
+        go through this method instead and never touch that stripping.
+        """
+        record = JSONSerializer.preprocess_search_hit(
+            pid, record_hit, links_factory=links_factory, **kwargs
+        )
+        for field in _INDEX_ONLY_FIELDS:
+            record["metadata"].pop(field, None)
+        return record
 
     def serialize(self, pid, record, links_factory=None, **kwargs):
         """Serialize a single record and persistent identifier.

--- a/rero_mef/query.py
+++ b/rero_mef/query.py
@@ -9,6 +9,15 @@ from invenio_records_rest.errors import InvalidQueryRESTError
 from invenio_records_rest.facets import default_facets_factory
 from invenio_records_rest.sorter import default_sorter_factory
 
+_DEFAULT_SEARCH_FIELDS = (
+    "pid",
+    "authorized_access_point",
+    "autocomplete_name",
+    "gnd.authorized_access_point",
+    "idref.authorized_access_point",
+    "rero.authorized_access_point",
+)
+
 
 def and_search_factory(self, search, query_parser=None):
     """Parse query using elasticsearch DSL query.
@@ -19,19 +28,19 @@ def and_search_factory(self, search, query_parser=None):
     """
 
     def _default_parser(qstr=None):
-        """Default parser that uses the Q() from elasticsearch_dsl."""
+        """Default parser for bare REST ``q`` searches.
+
+        Keep the search scoped to the common MEF fields the generic list routes
+        already expose, instead of allowing an unrestricted query across every
+        indexed field.
+        """
         if not qstr:
             return Q()
         return Q(
             "query_string",
             query=qstr,
+            fields=_DEFAULT_SEARCH_FIELDS,
             default_operator="AND",
-            fields=[
-                "*.authorized_access_point^5",
-                "*.variant_access_point^2",
-                "*.preferred_name^2",
-                "*",
-            ],
         )
 
     query_string = request.values.get("q")
@@ -63,3 +72,48 @@ def and_search_factory(self, search, query_parser=None):
         search = search.exclude("exists", field="deleted")
 
     return search, urlkwargs
+
+
+_QUERY_STRING_RESERVED_CHARS = '+-=!(){}[]^"~*?:\\/<>'
+
+
+def _escape_query_string(qstr):
+    """Escape Lucene/query_string reserved syntax characters in raw user input.
+
+    Prevents a raw search term from altering clause structure, switching
+    fields, or adding boosts when interpolated into a hand-built
+    ``query_string`` query. Whitespace is left untouched so multi-word input
+    still searches as separate terms.
+
+    :param qstr: raw user-supplied search term.
+    :returns: ``qstr`` with reserved characters backslash-escaped.
+    """
+    escaped = qstr.replace("\\", "\\\\")
+    for char in _QUERY_STRING_RESERVED_CHARS.replace("\\", ""):
+        escaped = escaped.replace(char, f"\\{char}")
+    return escaped.replace("&&", r"\&\&").replace("||", r"\|\|")
+
+
+def mef_ui_query_parser(qstr=None):
+    """Query parser for the MEF UI's own free-text search (``all_mef_search``).
+
+    The MEF UI has no field-qualified query of its own -- unlike API
+    consumers such as rero-ils's ``MEFProxyFactory``, which already builds
+    one (see ``MEFProxyMixin._get_query_params`` in rero-ils), it only has
+    the bare term typed into the search box. Builds that same clause here,
+    then hands it to the exact same unrestricted ``Q()`` construction as
+    :func:`and_search_factory`'s ``_default_parser`` (no ``fields``), so a
+    term typed into the MEF UI ranks results identically to the same term
+    arriving from rero-ils's autocomplete.
+
+    :param qstr: the raw search term (or ``None``/empty for a match-all).
+    :returns: an elasticsearch_dsl ``Q`` query.
+    """
+    if not qstr:
+        return Q()
+    escaped = _escape_query_string(qstr)
+    query = (
+        f'(idref.authorized_access_point:"{escaped}" OR gnd.authorized_access_point:"{escaped}")^10 '
+        f'OR (autocomplete_name:"{escaped}" OR "{escaped}")^4 OR ({escaped})'
+    )
+    return Q("query_string", query=query, default_operator="AND")

--- a/rero_mef/theme/templates/rero_mef/mef_detail.html
+++ b/rero_mef/theme/templates/rero_mef/mef_detail.html
@@ -44,12 +44,12 @@
         <div class="mef-detail-nav">
           <a class="mef-home-link" href="{{ home_url }}" title="All search"><i class="fa fa-home" aria-hidden="true"></i></a>
           <a class="mef-back-link" href="{{ back_url }}"><i class="fa fa-arrow-left" aria-hidden="true"></i> Back</a>
-          {%- if older_url %}
-          <a class="mef-older-link" href="{{ older_url }}"><i class="fa fa-step-backward" aria-hidden="true"></i> Older</a>
-          {%- endif %}
-          {%- if latest_url %}
-          <a class="mef-latest-link" href="{{ latest_url }}">Latest <i class="fa fa-step-forward" aria-hidden="true"></i></a>
-          {%- endif %}
+          {%- for item in older_urls %}
+          <a class="mef-older-link" href="{{ item.url }}"><i class="fa fa-step-backward" aria-hidden="true"></i> Older{% if older_urls|length > 1 %} ({{ item.source|upper }}){% endif %}</a>
+          {%- endfor %}
+          {%- for item in latest_urls %}
+          <a class="mef-latest-link" href="{{ item.url }}">Latest{% if latest_urls|length > 1 %} ({{ item.source|upper }}){% endif %} <i class="fa fa-step-forward" aria-hidden="true"></i></a>
+          {%- endfor %}
         </div>
         {%- if entity_label %}
         <span class="mef-detail-type-badge">{{ entity_label }}</span>

--- a/rero_mef/theme/views.py
+++ b/rero_mef/theme/views.py
@@ -345,16 +345,25 @@ def _own_relation_url(record_cls, entity_type, src, rel):
 
 
 def _compute_nav_urls(entity_type, record_cls, entities, resolved):
-    """Return (latest_url, older_url) navigation links for a MEF detail page.
+    """Return (latest_urls, older_urls) navigation links for a MEF detail page.
 
     Handles two redirect patterns:
     - ``redirect_to`` on source (GND): source is old; latest points to current.
     - ``redirect_from`` on source (IDREF): source is current; older points to old record.
     - Falls back to :func:`_reverse_relation_urls` when the pointer isn't on this
       record's own source sub-document.
+
+    Each linked source is resolved independently. Two sources can disagree
+    (e.g. both GND and IDREF redirected, to different successor records) --
+    when that happens both targets are returned rather than one silently
+    replacing the other; a source that agrees with one already found (same
+    URL) doesn't produce a second entry.
+
+    :returns: (latest_urls, older_urls) tuple of lists of ``{"source": src,
+        "url": url}`` dicts, in ``entities`` order; either list may be empty.
     """
-    latest_url = None
-    older_url = None
+    latest_by_url = {}
+    older_by_url = {}
     for src in entities:
         src_data = resolved.get(src)
         if not isinstance(src_data, dict):
@@ -362,17 +371,19 @@ def _compute_nav_urls(entity_type, record_cls, entities, resolved):
         found_older, found_latest = _own_relation_url(
             record_cls, entity_type, src, src_data.get("relation_pid")
         )
-        older_url = older_url or found_older
-        latest_url = latest_url or found_latest
-        if (not older_url or not latest_url) and (src_pid := src_data.get("pid")):
-            found_older, found_latest = _reverse_relation_urls(
+        if not (found_older and found_latest) and (src_pid := src_data.get("pid")):
+            rev_older, rev_latest = _reverse_relation_urls(
                 record_cls, entity_type, src, src_pid
             )
-            older_url = older_url or found_older
-            latest_url = latest_url or found_latest
-        if latest_url and older_url:
-            break
-    return latest_url, older_url
+            found_older = found_older or rev_older
+            found_latest = found_latest or rev_latest
+        if found_older:
+            older_by_url.setdefault(found_older, src)
+        if found_latest:
+            latest_by_url.setdefault(found_latest, src)
+    latest_urls = [{"source": src, "url": url} for url, src in latest_by_url.items()]
+    older_urls = [{"source": src, "url": url} for url, src in older_by_url.items()]
+    return latest_urls, older_urls
 
 
 def _mef_detail(entity_type, pid_value):
@@ -432,7 +443,7 @@ def _mef_detail(entity_type, pid_value):
             }
         )
 
-    latest_url, older_url = _compute_nav_urls(
+    latest_urls, older_urls = _compute_nav_urls(
         entity_type, config["record_cls"], record.entities, resolved
     )
     type_conflict = _detect_type_conflict(record)
@@ -442,8 +453,8 @@ def _mef_detail(entity_type, pid_value):
         version=__version__,
         home_url=url_for("rero_mef.all_mef_list"),
         back_url=_same_origin_referrer() or url_for("rero_mef.all_mef_list"),
-        latest_url=latest_url,
-        older_url=older_url,
+        latest_urls=latest_urls,
+        older_urls=older_urls,
         entity_label=config["label"],
         type_conflict=type_conflict,
         item_url=item_url,

--- a/rero_mef/utils.py
+++ b/rero_mef/utils.py
@@ -1176,14 +1176,24 @@ def get_mefs_endpoints():
     return mefs
 
 
-def generate(search, deleted):
-    """Lagging genarator."""
+def generate(search, deleted, exclude_fields=None):
+    """Lagging genarator.
+
+    :param exclude_fields: top-level keys to drop from each indexed hit
+        before serializing, e.g. index-only bookkeeping fields (entity,
+        md5, pid_numeric, sort_authorized_access_point, type_conflict)
+        that a consumer's ``additionalProperties: false`` schema rejects.
+    """
+    exclude_fields = exclude_fields or ()
     yield "["
     idx = 0
     for hit in search.scan():
         if idx != 0:
             yield ", "
-        yield json.dumps(hit.to_dict())
+        data = hit.to_dict()
+        for field in exclude_fields:
+            data.pop(field, None)
+        yield json.dumps(data)
         idx += 1
     for idx_deleted, record in enumerate(deleted):
         if idx + idx_deleted != 0:

--- a/rero_mef/views.py
+++ b/rero_mef/views.py
@@ -25,7 +25,7 @@ from .agents import AgentMefRecord
 from .all_mef import AllMefSearch
 from .concepts import ConceptMefRecord
 from .places import PlaceMefRecord
-from .query import and_search_factory
+from .query import and_search_factory, mef_ui_query_parser
 
 api_blueprint = Blueprint("api_blueprint", __name__, url_prefix="/")
 
@@ -239,7 +239,7 @@ def all_mef_search():
 
     search = AllMefSearch()
     try:
-        search, _ = and_search_factory(None, search)
+        search, _ = and_search_factory(None, search, query_parser=mef_ui_query_parser)
     except InvalidQueryRESTError as e:
         return jsonify(
             {

--- a/tests/api/test_agents_mef_rest.py
+++ b/tests/api/test_agents_mef_rest.py
@@ -10,7 +10,7 @@ from flask import url_for
 
 from rero_mef.agents import AgentMefRecord
 
-from ..utils import postdata
+from ..utils import postdata, strip_index_fields
 
 
 def test_view_agents_mef(
@@ -79,6 +79,7 @@ def test_mef_get_latest(
 ):
     """Test MEF get latest."""
     mef_data = agent_mef_record.add_information(resolve=True)
+    mef_data = strip_index_fields(mef_data)
     # No new record found
     assert AgentMefRecord.get_latest(pid_type="idref", pid="XXX") == {}
 
@@ -118,6 +119,7 @@ def test_agents_mef_get_idref_latest(
 ):
     """Test agents MEF get latest."""
     mef_data = agent_mef_idref_redirect_record.add_information(resolve=True)
+    mef_data = strip_index_fields(mef_data)
     # New IdRef record is one redirect IdRef record
     data = AgentMefRecord.get_latest(pid_type="idref", pid=agent_idref_record.pid)
     data.pop("_created")
@@ -136,33 +138,6 @@ def test_agents_mef_get_idref_latest(
     data.pop("_created")
     data.pop("_updated")
     assert data == mef_data
-
-
-def test_agents_mef_find_redirect_target_via_idref(
-    agent_mef_record,
-    agent_idref_record,
-    agent_gnd_record,
-    agent_rero_record,
-    agent_idref_redirect_record,
-    agent_mef_idref_redirect_record,
-):
-    """_find_redirect_target follows an IDREF redirect even when reached via GND.
-
-    The GND source itself was never redirected: the redirect only exists on
-    the IDREF source. Builds the old record's resolved shape by hand so the
-    check is deterministic -- old and new share the same GND/RERO pids, so a
-    real get_latest() lookup by GND could match either one first in
-    Elasticsearch, which would make an end-to-end assertion order-dependent.
-    """
-    data = {
-        "gnd": {"pid": agent_gnd_record.pid},
-        "idref": {"pid": agent_idref_record.pid},
-        "rero": {"pid": agent_rero_record.pid},
-    }
-    assert AgentMefRecord._find_redirect_target(data) == (
-        "idref",
-        agent_idref_redirect_record.pid,
-    )
 
 
 def test_agents_mef_get_updated(
@@ -284,3 +259,40 @@ def test_agents_mef_get_updated(
         },
         {"pid": "4"},
     ]
+
+
+def test_agents_mef_get_idref_latest_chain(
+    agent_mef_record,
+    agent_idref_record,
+    agent_gnd_record,
+    agent_rero_record,
+    agent_idref_redirect_record,
+    agent_mef_idref_redirect_record,
+    agent_idref_redirect_2_record,
+    agent_mef_idref_redirect_2_record,
+):
+    """A -> B -> C IDREF redirect chain resolves all the way to C.
+
+    Regression test: B has its own ``redirect_from`` relation_pid (documenting
+    that it superseded A), which must not stop ``get_latest`` from also
+    looking up whether B itself was later superseded by C. Placed last in the
+    module: it creates a fourth MEF record, and earlier tests in this file
+    (``test_agents_mef_get_updated``) hard-code the module's pid layout,
+    including pid "4" not existing yet.
+    """
+    mef_data = agent_mef_idref_redirect_2_record.add_information(resolve=True)
+    mef_data = strip_index_fields(mef_data)
+
+    # Starting from the oldest record (A) resolves through B all the way to C.
+    data = AgentMefRecord.get_latest(pid_type="idref", pid=agent_idref_record.pid)
+    data.pop("_created")
+    data.pop("_updated")
+    assert data == mef_data
+
+    # Starting from the middle record (B) also resolves to C, not to B itself.
+    data = AgentMefRecord.get_latest(
+        pid_type="idref", pid=agent_idref_redirect_record.pid
+    )
+    data.pop("_created")
+    data.pop("_updated")
+    assert data == mef_data

--- a/tests/api/test_concepts_mef_rest.py
+++ b/tests/api/test_concepts_mef_rest.py
@@ -10,7 +10,7 @@ from flask import url_for
 
 from rero_mef.concepts import ConceptMefRecord
 
-from ..utils import postdata
+from ..utils import postdata, strip_index_fields
 
 
 def test_view_concepts_mef(
@@ -78,6 +78,7 @@ def test_concepts_mef_get_latest(
 ):
     """Test concepts MEF get latest."""
     mef_data = concept_mef_rero_record.add_information(resolve=True)
+    mef_data = strip_index_fields(mef_data)
     # No new record found
     assert ConceptMefRecord.get_latest(pid_type="rero", pid="XXX") == {}
 
@@ -88,6 +89,7 @@ def test_concepts_mef_get_latest(
     assert data == mef_data
 
     mef_data = concept_mef_idref_redirect_record.add_information(resolve=True)
+    mef_data = strip_index_fields(mef_data)
     # New IdRef record is old IdRef record
     data = ConceptMefRecord.get_latest(
         pid_type="idref", pid=concept_idref_redirect_record.pid

--- a/tests/api/test_places_mef_rest.py
+++ b/tests/api/test_places_mef_rest.py
@@ -10,7 +10,7 @@ from flask import url_for
 
 from rero_mef.places import PlaceMefRecord
 
-from ..utils import postdata
+from ..utils import postdata, strip_index_fields
 
 
 def test_view_places_mef(
@@ -74,6 +74,7 @@ def test_places_mef_get_latest(
 ):
     """Test places MEF get latest."""
     mef_data = place_mef_idref_redirect_record.add_information(resolve=True)
+    mef_data = strip_index_fields(mef_data)
     # New IdRef record is old IdRef record
     data = PlaceMefRecord.get_latest(
         pid_type="idref", pid=place_idref_redirect_record.pid

--- a/tests/fixtures/agents_data.py
+++ b/tests/fixtures/agents_data.py
@@ -485,6 +485,23 @@ def agent_idref_redirect_data():
 
 
 @pytest.fixture(scope="module")
+def agent_idref_redirect_2_data():
+    """Agent IDREF record, third hop of an A -> B -> C redirect chain."""
+    return {
+        "pid": "IDREF_REDIRECT_2",
+        "type": "bf:Person",
+        "date_of_birth": "....",
+        "date_of_death": "1540",
+        "language": ["fre"],
+        "preferred_name": "Brissé, Nicolas, grammairien",
+        "authorized_access_point": "Brissé, Nicolas, ....-1540, grammairien",
+        "gender": "male",
+        "$schema": "https://mef.rero.ch/schemas/agents_idref/idref-agent-v0.0.1.json",
+        "relation_pid": {"type": "redirect_from", "value": "IDREF_REDIRECT"},
+    }
+
+
+@pytest.fixture(scope="module")
 def agent_mef_data():
     """Agent MEF record."""
     return {
@@ -515,6 +532,19 @@ def agent_mef_idref_redirect_data():
         "gnd": {"$ref": "https://mef.rero.ch/api/agents/gnd/12391664X"},
         "rero": {"$ref": "https://mef.rero.ch/api/agents/rero/A023655346"},
         "idref": {"$ref": "https://mef.rero.ch/api/agents/idref/IDREF_REDIRECT"},
+        "viaf_pid": "66739143",
+        "type": "bf:Person",
+    }
+
+
+@pytest.fixture(scope="module")
+def agent_mef_idref_redirect_2_data():
+    """Agent MEF record for the third (C) IDREF record of an A -> B -> C chain."""
+    return {
+        "$schema": "https://mef.rero.ch/schemas/mef/mef-v0.0.1.json",
+        "gnd": {"$ref": "https://mef.rero.ch/api/agents/gnd/12391664X"},
+        "rero": {"$ref": "https://mef.rero.ch/api/agents/rero/A023655346"},
+        "idref": {"$ref": "https://mef.rero.ch/api/agents/idref/IDREF_REDIRECT_2"},
         "viaf_pid": "66739143",
         "type": "bf:Person",
     }

--- a/tests/fixtures/agents_records.py
+++ b/tests/fixtures/agents_records.py
@@ -29,6 +29,12 @@ def agent_idref_redirect_record(app, agent_idref_redirect_data):
 
 
 @pytest.fixture(scope="module")
+def agent_idref_redirect_2_record(app, agent_idref_redirect_2_data):
+    """Create the third (C) IdRef record of an A -> B -> C redirect chain."""
+    return create_record(AgentIdrefRecord, agent_idref_redirect_2_data)
+
+
+@pytest.fixture(scope="module")
 def agent_gnd_record(app, agent_gnd_data):
     """Create a GND record."""
     return create_record(AgentGndRecord, agent_gnd_data)
@@ -98,6 +104,14 @@ def agent_mef_idref_redirect_record(
 ):
     """Create a IdRef record."""
     return create_record(AgentMefRecord, agent_mef_idref_redirect_data)
+
+
+@pytest.fixture(scope="module")
+def agent_mef_idref_redirect_2_record(
+    app, agent_mef_idref_redirect_2_data, agent_idref_redirect_2_record
+):
+    """Create the MEF record for the third (C) IDREF record of an A -> B -> C chain."""
+    return create_record(AgentMefRecord, agent_mef_idref_redirect_2_data)
 
 
 @pytest.fixture(scope="module")

--- a/tests/ui/test_theme_views.py
+++ b/tests/ui/test_theme_views.py
@@ -5,6 +5,11 @@
 
 from flask import url_for
 
+from rero_mef.agents import AgentGndRecord, AgentIdrefRecord, AgentMefRecord
+from rero_mef.utils import build_ref_string
+
+from ..utils import create_record
+
 
 def test_robots_txt(client):
     """robots.txt disallows all UI paths."""
@@ -113,3 +118,106 @@ def test_agent_detail_crosstype_redirect(client, agent_mef_crosstype_redirect_re
     body = res.get_data(as_text=True)
     assert "mef-type-conflict-alert" in body
     assert "mef-conflict-link" not in body
+
+
+def test_agent_detail_conflicting_latest_targets(app, client):
+    """GND and IDREF redirecting to two different records both show up as Latest links.
+
+    Self-contained fixtures (unique pids) rather than the shared module-scoped
+    ones, since this needs a record whose GND *and* IDREF sources each point to
+    a different successor -- none of the existing shared fixtures combine both
+    at once, and mutating them would affect other tests in this module.
+    """
+    gnd_old = create_record(
+        AgentGndRecord,
+        {
+            "pid": "9990001",
+            "type": "bf:Person",
+            "authorized_access_point": "Conflict GND Old",
+            "relation_pid": {"type": "redirect_to", "value": "9990002"},
+            "$schema": "https://mef.rero.ch/schemas/agents_gnd/gnd-agent-v0.0.1.json",
+        },
+    )
+    gnd_new = create_record(
+        AgentGndRecord,
+        {
+            "pid": "9990002",
+            "type": "bf:Person",
+            "authorized_access_point": "Conflict GND New",
+            "$schema": "https://mef.rero.ch/schemas/agents_gnd/gnd-agent-v0.0.1.json",
+        },
+    )
+    idref_old = create_record(
+        AgentIdrefRecord,
+        {
+            "pid": "9990003",
+            "type": "bf:Person",
+            "authorized_access_point": "Conflict IdRef Old",
+            "$schema": "https://mef.rero.ch/schemas/agents_idref/idref-agent-v0.0.1.json",
+        },
+    )
+    idref_new = create_record(
+        AgentIdrefRecord,
+        {
+            "pid": "9990004",
+            "type": "bf:Person",
+            "authorized_access_point": "Conflict IdRef New",
+            "relation_pid": {"type": "redirect_from", "value": "9990003"},
+            "$schema": "https://mef.rero.ch/schemas/agents_idref/idref-agent-v0.0.1.json",
+        },
+    )
+    mef_old = create_record(
+        AgentMefRecord,
+        {
+            "gnd": {
+                "$ref": build_ref_string(
+                    entity_type="agents", entity_name="gnd", entity_pid=gnd_old.pid
+                )
+            },
+            "idref": {
+                "$ref": build_ref_string(
+                    entity_type="agents", entity_name="idref", entity_pid=idref_old.pid
+                )
+            },
+            "$schema": "https://mef.rero.ch/schemas/mef/mef-v0.0.1.json",
+        },
+    )
+    mef_gnd_new = create_record(
+        AgentMefRecord,
+        {
+            "gnd": {
+                "$ref": build_ref_string(
+                    entity_type="agents", entity_name="gnd", entity_pid=gnd_new.pid
+                )
+            },
+            "$schema": "https://mef.rero.ch/schemas/mef/mef-v0.0.1.json",
+        },
+    )
+    mef_idref_new = create_record(
+        AgentMefRecord,
+        {
+            "idref": {
+                "$ref": build_ref_string(
+                    entity_type="agents", entity_name="idref", entity_pid=idref_new.pid
+                )
+            },
+            "$schema": "https://mef.rero.ch/schemas/mef/mef-v0.0.1.json",
+        },
+    )
+
+    res = client.get(f"/agents/{mef_old.pid}")
+    assert res.status_code == 200
+    body = res.get_data(as_text=True)
+    assert body.count("mef-latest-link") == 2
+    assert f"/agents/latest/gnd:{gnd_new.pid}" in body
+    assert f"/agents/latest/idref:{idref_new.pid}" in body
+    assert "Latest (GND)" in body
+    assert "Latest (IDREF)" in body
+
+    # each redirect route resolves to the correct, distinct MEF record
+    res = client.get(f"/agents/latest/gnd:{gnd_new.pid}", follow_redirects=True)
+    assert res.status_code == 200
+    assert res.request.path == f"/agents/{mef_gnd_new.pid}"
+    res = client.get(f"/agents/latest/idref:{idref_new.pid}", follow_redirects=True)
+    assert res.status_code == 200
+    assert res.request.path == f"/agents/{mef_idref_new.pid}"

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -9,12 +9,24 @@ from unittest.mock import Mock
 from flask import url_for
 from invenio_accounts.testutils import login_user_via_session
 
+from rero_mef.api_mef import _INDEX_ONLY_FIELDS
+
 
 def create_record(cls, data, delete_pid=False):
     """Create a record in DB and index it."""
     record = cls.create(data=data, delete_pid=delete_pid, dbcommit=True, reindex=True)
     cls.flush_indexes()
     return record
+
+
+def strip_index_fields(data):
+    """Remove ES-index-only fields (see ``rero_mef.api_mef._INDEX_ONLY_FIELDS``).
+
+    Useful when comparing ``get_latest()``'s output (already stripped) against
+    a record fetched via a different path, such as ``add_information()``,
+    that doesn't strip them.
+    """
+    return {k: v for k, v in data.items() if k not in _INDEX_ONLY_FIELDS}
 
 
 def create_and_login_monitoring_user(app, client):


### PR DESCRIPTION
* consolidate get_latest, previously triplicated across agents/concepts/places mef/api.py, into EntityMefRecord in api_mef.py
* fix two bugs found while deduplicating: the idref reverse lookup now iterates every match for a redirect_from hit instead of only checking the first (a record can be both redirect_to'd and redirect_from'd at once); the visited cycle-guard is now keyed by (pid_type, pid) instead of a bare pid
* strip index-only fields (entity, md5, pid_numeric, sort_authorized_access_point, type_conflict) from get_latest's output so it matches the record's public/schema-clean shape
* also consolidate replace_refs, add_information, and the three MEF indexers' bulk_index (new shared MefIndexer base) into api_mef.py, dropping ~260 lines of near-identical per-family code
* update the get_latest tests to account for the stripped fields

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MEF detail page “Latest” navigation now aggregates multiple redirect targets (including reverse-redirect cases).
  * MEF UI free-text search improved to prioritize access points, names, and identifiers.
* **Bug Fixes**
  * “Latest” resolution for MEF records is more reliable, with redirect-cycle protection and correct newest-target selection.
  * Public MEF responses no longer include internal/index-only fields.
* **Tests**
  * Updated REST/UI tests to normalize outputs against the new “Latest” multi-target behavior, including a new conflicting-target UI coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->