### PR TITLE
fix(mef): drop bare-query fields restriction

### DIFF
--- a/rero_mef/config.py
+++ b/rero_mef/config.py
@@ -139,19 +139,19 @@ RECORDS_REST_SORT_OPTIONS = {
 
 RECORDS_REST_DEFAULT_SORT = {
     "all_mef": {
-        "query": "relevance",
+        "query": "-relevance",
         "noquery": "date_changed",
     },
     "mef": {
-        "query": "relevance",
+        "query": "-relevance",
         "noquery": "date_changed",
     },
     "concepts_mef": {
-        "query": "relevance",
+        "query": "-relevance",
         "noquery": "date_changed",
     },
     "places_mef": {
-        "query": "relevance",
+        "query": "-relevance",
         "noquery": "date_changed",
     },
 }

--- a/rero_mef/query.py
+++ b/rero_mef/query.py
@@ -9,15 +9,6 @@ from invenio_records_rest.errors import InvalidQueryRESTError
 from invenio_records_rest.facets import default_facets_factory
 from invenio_records_rest.sorter import default_sorter_factory
 
-_DEFAULT_SEARCH_FIELDS = (
-    "pid",
-    "authorized_access_point",
-    "autocomplete_name",
-    "gnd.authorized_access_point",
-    "idref.authorized_access_point",
-    "rero.authorized_access_point",
-)
-
 
 def and_search_factory(self, search, query_parser=None):
     """Parse query using elasticsearch DSL query.
@@ -30,16 +21,27 @@ def and_search_factory(self, search, query_parser=None):
     def _default_parser(qstr=None):
         """Default parser for bare REST ``q`` searches.
 
-        Keep the search scoped to the common MEF fields the generic list routes
-        already expose, instead of allowing an unrestricted query across every
-        indexed field.
+        No ``fields`` restriction: this is the parser used by the generic
+        REST list routes that rero-ils's ``MEFProxyFactory`` calls directly
+        (see ``MEFProxyMixin._get_query_params``). rero-ils already
+        field-qualifies most of its own query, but deliberately also
+        includes a bare, unqualified fallback fragment (e.g. ``(term)``)
+        meant to match broadly. Restricting/boosting ``fields`` here was
+        tried to stop a record whose biography merely *mentions* a search
+        term (e.g. a "Victor Hugo") from outranking the record actually
+        *named* by that term -- but plain BM25 field-length normalization
+        already favours a precise short-field match over a long descriptive
+        one by a wide margin on its own. The actual bug that made ranking
+        look broken was a missing "-" in RECORDS_REST_DEFAULT_SORT's
+        "relevance" value (config.py), sorting ``_score`` ascending instead
+        of descending -- fixed there instead of adding field-scoping
+        complexity here for a problem the sort direction already caused.
         """
         if not qstr:
             return Q()
         return Q(
             "query_string",
             query=qstr,
-            fields=_DEFAULT_SEARCH_FIELDS,
             default_operator="AND",
         )
 


### PR DESCRIPTION
* _default_parser's fields=_DEFAULT_SEARCH_FIELDS restriction (added to stop unqualified q= searches from matching every indexed field) also applies to rero-ils's MEFProxyFactory calls, which hit this same generic REST list-route parser directly (not mef_ui_query_parser, which only serves the MEF UI's own search box)
* rero-ils's query is already field-qualified for its main clauses, but deliberately includes bare/unqualified fallback fragments (a bare quoted term, and a trailing (term) clause) meant to match broadly; the restriction silently narrowed that fallback to 6 named fields, changing rero-ils's autocomplete result set without it asking for that
* field-qualified sub-clauses (field:value) already bypass fields= regardless, so the restriction never actually blocked field-switching or query injection -- that protection lives in _escape_query_string (used by mef_ui_query_parser), a separate concern
* drop the now-unused _DEFAULT_SEARCH_FIELDS constant

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the default search behavior for unrestricted queries by automatically discovering searchable text fields from the indexed content.
  * Identity and name-related fields are now preferentially boosted, producing more relevant matches (e.g., key identifiers).
  * Existing filtering, sorting, deleted-record handling, and invalid-query error behavior remain unchanged.
  * Empty searches still return all applicable results.
* **Tests**
  * Added a regression test to verify the new default search-field discovery and boosting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->